### PR TITLE
Adding missing install target for linux notification resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,7 @@ setup(
             'list = catkin_tools.verbs.catkin_list:description',
         ],
     },
+    package_data={
+        'catkin_tools': [
+            'notifications/resources/linux/*.png'] },
 )


### PR DESCRIPTION
The libnotify icon wasn't showing up on linux for me because the resources weren't installed. Note that this doesn't add the rules for the OS X files. Fixes issue mentioned in https://github.com/catkin/catkin_tools/issues/33#issuecomment-41253300
