### PR TITLE
build: changing behavior to merge develspace

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -543,7 +543,7 @@ def build_isolated_workspace(
     # All executors have shutdown
     sys.stdout.write("\x1b]2;\x07")
     if not errors:
-        if not context.merge_devel:
+        if context.isolate_devel:
             if not context.install:
                 _create_unmerged_devel_setup(context)
             else:

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -74,8 +74,8 @@ def prepare_arguments(parser):
         help='The path to the build space (default "build")')
     add('--devel', '--devel-space', default=None,
         help='Sets the target devel space (default "devel")')
-    add('--merge-devel', action='store_true', default=False,
-        help='Build each catkin package into a common devel space.')
+    add('--isolate-devel', action='store_true', default=False,
+        help='Build products from each catkin package into isolated devel spaces.')
     add('--install-space', dest='install_space', default=None,
         help='Sets the target install space (default "install")')
     add('--install', action='store_true', default=False,
@@ -153,7 +153,7 @@ def main(opts):
         source_space=opts.source,
         build_space=opts.build,
         devel_space=opts.devel,
-        merge_devel=opts.merge_devel,
+        isolate_devel=opts.isolate_devel,
         install_space=opts.install_space,
         install=opts.install,
         isolate_install=opts.isolate_install,

--- a/catkin_tools/verbs/catkin_build/context.py
+++ b/catkin_tools/verbs/catkin_build/context.py
@@ -41,7 +41,7 @@ class Context(object):
         build_space=None,
         devel_space=None,
         install_space=None,
-        merge_devel=False,
+        isolate_devel=False,
         install=False,
         isolate_install=False,
         cmake_args=None,
@@ -61,8 +61,8 @@ class Context(object):
         :type devel_space: str
         :param install_space: target location of install space, defaults to '<workspace>/install'
         :type install_space: str
-        :param merge_devel: devel space will be shared for all packages if True, default is False
-        :type merge_devel: bool
+        :param isolate_devel: each package will have its own develspace if True, default is False
+        :type isolate_devel: bool
         :param install: packages will be installed by invoking ``make install``, defaults to False
         :type install: bool
         :param isolate_install: packages will be installed to separate folders if True, defaults to False
@@ -88,7 +88,7 @@ class Context(object):
         self.install_space = os.path.join(self.workspace, 'install' + ss) if install_space is None else install_space
         self.destdir = os.environ['DESTDIR'] if 'DESTDIR' in os.environ else None
         # Handle build options
-        self.merge_devel = merge_devel
+        self.isolate_devel = isolate_devel
         self.install = install
         self.isolate_install = isolate_install
         # Handle additional cmake and make arguments
@@ -108,7 +108,7 @@ class Context(object):
                 clr("@{cf}DESTDIR:@|                     @{yf}{_Context__destdir}@|"),
             ],
             [
-                clr("@{cf}Merge Develspaces:@|           @{yf}{_Context__merge_devel}@|"),
+                clr("@{cf}Isolate Develspaces:@|         @{yf}{_Context__isolate_devel}@|"),
                 clr("@{cf}Install Packages:@|            @{yf}{_Context__install}@|"),
                 clr("@{cf}Isolate Installs:@|            @{yf}{_Context__isolate_install}@|"),
             ],
@@ -204,14 +204,14 @@ class Context(object):
         self.__destdir = value
 
     @property
-    def merge_devel(self):
-        return self.__merge_devel
+    def isolate_devel(self):
+        return self.__isolate_devel
 
-    @merge_devel.setter
-    def merge_devel(self, value):
+    @isolate_devel.setter
+    def isolate_devel(self, value):
         if self.__locked:
             raise RuntimeError("Setting of context members is not allowed while locked.")
-        self.__merge_devel = value
+        self.__isolate_devel = value
 
     @property
     def install(self):

--- a/catkin_tools/verbs/catkin_build/job.py
+++ b/catkin_tools/verbs/catkin_build/job.py
@@ -102,7 +102,7 @@ def create_env_file(package, context):
     sources = []
     source_snippet = ". {source_path}"
     # If installing to isolated folders or not installing, but devel spaces are not merged
-    if (context.install and context.isolate_install) or (not context.install and not context.merge_devel):
+    if (context.install and context.isolate_install) or (not context.install and context.isolate_devel):
         # Source each package's install or devel space
         space = context.install_space if context.install else context.devel_space
         # Get the recursive dependcies
@@ -134,10 +134,10 @@ class CMakeJob(Job):
         # Setup build variables
         pkg_dir = os.path.join(self.context.source_space, self.package_path)
         build_space = create_build_space(self.context.build_space, self.package.name)
-        if self.context.merge_devel:
-            devel_space = self.context.devel_space
-        else:
+        if self.context.isolate_devel:
             devel_space = os.path.join(self.context.devel_space, self.package.name)
+        else:
+            devel_space = self.context.devel_space
         if self.context.isolate_install:
             install_space = os.path.join(self.context.install_space, self.package.name)
         else:
@@ -175,7 +175,7 @@ class CMakeJob(Job):
                 return commands
         else:  # Create it in the devel space
             setup_file_path = os.path.join(devel_space, 'setup.sh')
-            if self.context.merge_devel and os.path.exists(setup_file_path):
+            if not self.context.isolate_devel and os.path.exists(setup_file_path):
                 # Do not replace existing setup.sh if devel space is merged
                 return commands
         # Create the setup file other packages will source when depending on this package
@@ -239,10 +239,10 @@ class CatkinJob(Job):
         # Setup build variables
         pkg_dir = os.path.join(self.context.source_space, self.package_path)
         build_space = create_build_space(self.context.build_space, self.package.name)
-        if self.context.merge_devel:
-            devel_space = self.context.devel_space
-        else:
+        if self.context.isolate_devel:
             devel_space = os.path.join(self.context.devel_space, self.package.name)
+        else:
+            devel_space = self.context.devel_space
         if self.context.isolate_install:
             install_space = os.path.join(self.context.install_space, self.package.name)
         else:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ For example, the ``install: build --install`` alias exists in the default file, 
 
 .. code-block:: yaml
 
-    install: build --install --merge-devel
+    install: build --install 
 
 You can also nullify or unset aliases by setting their values to ``null``.
 So, for example, the ``ls: list`` alias is defined in the default aliases, you can override it with this entry in a custom file:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -82,12 +82,12 @@ def test_get_verb_aliases():
     base_path = os.path.join(test_folder, 'verb_aliases')
     with open(os.path.join(base_path, '01-my-custom-aliases.yml'), 'w') as f:
         f.write("""\
-b: build --merge-devel
+b: build --isolate-devel
 ls: null
 """)
     aliases = config.get_verb_aliases(test_folder)
     assert 'b' in aliases
-    assert aliases['b'] == 'build --merge-devel', aliases['b']
+    assert aliases['b'] == 'build --isolate-devel', aliases['b']
     assert 'ls' not in aliases
     # Test a bad alias files
     bad_path = os.path.join(base_path, '02-bad.yaml')


### PR DESCRIPTION
This patch makes the following changes:
- Makes the default build behavior merge all develspaces
- Removes the --merge-devel argument
- Creates a new argument: --isolate-devel = 'not --merge-devel'
