### PR TITLE
catkin_build: print log if stderr is not empty (linux side only), see #1

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -459,7 +459,7 @@ def build_isolated_workspace(
                 out.command_started(event.package, event.data['cmd'], event.data['location'])
 
             if event.event_type == 'command_log':
-                out.command_log(event.package, event.data['message'])
+                out.command_log(event.package, event.data['message'], event.data['source'])
 
             if event.event_type == 'command_failed':
                 out.command_failed(event.package, event.data['cmd'], event.data['location'], event.data['retcode'])

--- a/catkin_tools/verbs/catkin_build/run_common.py
+++ b/catkin_tools/verbs/catkin_build/run_common.py
@@ -1,0 +1,16 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE_STDOUT = 0
+SOURCE_STDERR = 1


### PR DESCRIPTION
As discussed in #1, opening a pull request to make discussion easier. Not ready for merge! This is merely a testbed to see if stdout/stderr interleaving poses an issue.

If something got printed on stderr by a build command, the user will want
to know about it. So gather stderr separately from stdout and check if
it is non-empty when the command finishes.