### PR TITLE
build: Adding --extend argument to control workspace parent

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -18,6 +18,7 @@ import os
 import stat
 import sys
 import time
+import re
 
 from multiprocessing import cpu_count
 from threading import Lock
@@ -54,6 +55,7 @@ from .common import get_recursive_run_depends_in_workspace
 from .common import is_tty
 from .common import log
 from .common import wide_log
+from .common import run_command
 
 from .executor import Executor
 from .executor import ExecutorEvent
@@ -62,6 +64,88 @@ from .job import CatkinJob
 from .job import CMakeJob
 
 from .output import OutputController
+
+
+def get_resultspace_environment(result_space_path, quiet=False):
+    """Get the environemt variables which result from sourcing another catkin
+    workspace's setup files as the string output of `cmake -E environment`.
+    This command is used to be as portable as possible.
+
+    :param result_space_path: path to a Catkin result-space whose environment should be loaded, ``str``
+    :param quiet: don't throw exceptions, ``bool``
+
+    :returns: a carriage-return-delimted string of environment variables, ``str``
+    """
+    # Check to make sure result_space_path is a valid directory
+    if not os.path.isdir(result_space_path):
+        if quiet:
+            return dict()
+        raise IOError(
+            "Cannot load environment from resultspace \"%s\" because it does not "
+            "exist." % result_space_path
+        )
+
+    # Check to make sure result_space_path contains a `.catkin` file
+    # TODO: `.catkin` should be defined somewhere as an atom in catkin_pkg
+    if not os.path.exists(os.path.join(result_space_path, '.catkin')):
+        if quiet:
+            return dict()
+        raise IOError(
+            "Cannot load environment from resultspace \"%s\" because it does not "
+            "appear to be a catkin-generated resultspace (missing .catkin marker "
+            "file)." % result_space_path
+        )
+
+    # Determine the shell to use to source the setup file
+    shell_path = os.environ['SHELL']
+    (_, shell_name) = os.path.split(shell_path)
+
+    # Use fallback shell if using a non-standard shell
+    if shell_name not in ['bash', 'zsh']:
+        shell_name = 'bash'
+
+    # Check to make sure result_space_path contains the appropriate setup file
+    setup_file_path = os.path.join(result_space_path, 'setup.%s' % shell_name)
+    if not os.path.exists(setup_file_path):
+        if quiet:
+            return dict()
+        raise IOError(
+            "Cannot load environment from resultspace \"%s\" because the "
+            "required setup file \"%s\" does not exist." % (result_space_path, setup_file_path)
+        )
+
+    # Construct a command list which sources the setup file and prints the env to stdout
+    norc_flags = {'bash': '--norc', 'zsh': '-f'}
+    subcommand = 'source %s; cmake -E environment' % (setup_file_path)
+
+    command = [
+        shell_path,
+        norc_flags[shell_name],
+        '-c', subcommand]
+
+    # Run the command to source the other environment and output all environment variables
+    blacklisted_keys = ('_', 'PWD')
+    env_regex = re.compile('(.+?)=(.*)$', re.M)
+    env_dict = dict()
+
+    for line in run_command(command, cwd=os.getcwd()):
+        if isinstance(line, str):
+            matches = env_regex.findall(line)
+            for (key, value) in matches:
+                if key not in blacklisted_keys:
+                    env_dict[key] = value.rstrip()
+
+    return env_dict
+
+
+def load_resultspace_environment(result_space_path):
+    """Load the environemt variables which result from sourcing another
+    workspace path into this process's environment.
+    
+    :param result_space_path: path to a Catkin result-space whose environment should be loaded, ``str``
+    """
+    env_dict = get_resultspace_environment(result_space_path)
+    os.environ.update(env_dict)
 
 
 def get_ready_packages(packages, running_jobs, completed):

--- a/docs/commands/catkin_build.rst
+++ b/docs/commands/catkin_build.rst
@@ -404,6 +404,44 @@ This ends up being pretty confusing, so when interleaved output is used ``catkin
 
 When you use ``-p 1`` and ``-v`` at the same time, ``-i`` is implicitly added.
 
+Explicitly Specifying the Environment with ``catkin build``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Normally, a catkin workspace automatically "extends" the other workspaces that
+have previously been sourced in your environment. Each time you source a catkin
+setup file from a result-space (devel-space or install-space), it sets the
+``$CMAKE_PREFIX_PATH`` in your environment, and this is used to build the next
+workspace. This is also sometimes referred to as "workspace chaining" and
+sometimes the extended workspace is referred to as a "parent" workspace.
+
+With ``catkin build``, you can explicitly set the workspace you want to extend,
+using the ``--extend`` argument. This is equivalent to sourcing a setup file,
+building, and then reverting to the environment before sourcing the setup file. 
+
+Note that in case the desired parent workspace is different from one already
+being used, using the ``--extend`` argument also enables the ``--force-cmake``
+argument.
+
+For example, regardless of your current environment variable settings (like
+``$CMAKE_PREFIX_PATH``), this will build your workspace against the
+``/opt/ros/hydro`` install space.
+
+.. code-block:: bash
+
+    $ pwd
+    /path/to/my_catkin_ws
+
+    $ echo $CMAKE_PREFIX_PATH
+    /path/to/other_ws:/opt/ros/hydro
+
+    $ catkin build --extend /opt/ros/hydro
+    ...
+
+    $ source devel/setup.bash
+
+    $ echo $CMAKE_PREFIX_PATH
+    /path/to/my_catkin_ws:/opt/ros/hydro
+
 Running tests with ``catkin build``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This adds `--extend` as an argument to `catkin build` which enables explicit chaining to/overlaying of another workspace. It is equivalent to sourcing the given workspace in a subshell building the current workspace, and then exiting that shell. For this to work properly, it requires that any variables defined in the current environment as a result of the previously-sourced workspace can be rolled back by their respective rollback hooks.

The `--extend` flag calls the `load_workspace_environment()` function at the beginning of the `catkin build` verb invocation which sources another workspace's environment before initiating the build process, but does not change the caller's environment.  Calling `catkin build --extend` also implicitly enables `--force-cmake`. This makes it easy to switch the "parents" of a workspace.

This PR also prints out the `$CMAKE_PREFIX_PATH` used by the workspace at the beginning of the build for greater visibility.
- [x] decide on the argument name (should be based on standard name for this action as decided in [rep#78](https://github.com/ros-infrastructure/rep/issues/78#issuecomment-45562093)
  - `--extend` (current)
  - `--extend-ws` (old)
  - `--overlay`
  - `--chain`
- [x] add documentation for this argument
