### PR TITLE
build: add an internal GNU make job server, see #84

### DIFF
--- a/catkin_tools/make_jobserver.py
+++ b/catkin_tools/make_jobserver.py
@@ -72,7 +72,7 @@ all:
 ''')
         close(fd)
 
-        ret = call(['make', '-f', makefile, '-j2'])
+        ret = call(['make', '-f', makefile, '-j2'], stdout=PIPE, stderr=PIPE)
 
         unlink(makefile)
         return (ret == 0)

--- a/catkin_tools/make_jobserver.py
+++ b/catkin_tools/make_jobserver.py
@@ -1,0 +1,134 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from os import pipe, write, close, unlink, read
+from multiprocessing import cpu_count
+from tempfile import mkstemp
+from subprocess import call, PIPE
+from termios import FIONREAD
+
+import fcntl
+import array
+
+# from .common import log
+
+job_server_instance = None
+
+
+class MakeJobServer:
+    """
+    This class implements a GNU make job server.
+    """
+
+    @staticmethod
+    def get_instance():
+        return job_server_instance
+
+    def __init__(self, num_jobs=None):
+        global job_server_instance
+        assert(not job_server_instance)
+        job_server_instance = self
+
+        if not num_jobs:
+            try:
+                num_jobs = cpu_count()
+            except NotImplementedError:
+                # log('Failed to determine the cpu_count, falling back to 1 jobs as the default.')
+                num_jobs = 1
+        else:
+            num_jobs = int(num_jobs)
+
+        self.num_jobs = num_jobs
+        self.pipe = pipe()
+
+        # Initialize the pipe with num_jobs tokens
+        for i in range(num_jobs):
+            write(self.pipe[1], b'+')
+
+        self.supported = self._testSupport()
+
+    def _testSupport(self):
+        """
+        Test if the system 'make' supports the job server implementation
+        """
+
+        fd, makefile = mkstemp()
+        write(fd, b'''
+all:
+\techo $(MAKEFLAGS) | grep -- '--jobserver-fds'
+''')
+        close(fd)
+
+        ret = call(['make', '-f', makefile, '-j2'])
+
+        unlink(makefile)
+        return (ret == 0)
+
+    def make_arguments(self):
+        """
+        Get required arguments for spawning child make processes
+        """
+
+        return ["--jobserver-fds=%d,%d" % self.pipe, "-j"]
+
+    def num_running_jobs(self):
+        """
+        Try to estimate the number of currently running jobs
+        """
+
+        try:
+            buf = array.array('i', [0])
+            if fcntl.ioctl(self.pipe[0], FIONREAD, buf) == 0:
+                return self.num_jobs - buf[0]
+        except NotImplementedError:
+            pass
+        except OSError:
+            pass
+
+        return self.num_jobs
+
+    def obtain(self):
+        """
+        Obtain a job server token. Be sure to call release() to avoid
+        deadlocks.
+        """
+
+        while True:
+            try:
+                token = read(self.pipe[0], 1)
+                return token
+            except OSError as e:
+                if e.errno == errno.EINTR:
+                    continue
+                else:
+                    raise
+
+    def release(self):
+        """
+        Release a job server token.
+        """
+
+        write(self.pipe[1], b'+')
+
+    def __enter__(self):
+        if self.supported:
+            self.obtain()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.supported:
+            self.release()
+        return False

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -52,6 +52,7 @@ from catkin_tools.common import get_recursive_run_depends_in_workspace
 from catkin_tools.common import is_tty
 from catkin_tools.common import log
 from catkin_tools.common import wide_log
+from catkin_tools.make_jobserver import MakeJobServer
 
 from .common import get_build_type
 
@@ -594,11 +595,12 @@ def build_isolated_workspace(
                     # Print them in order of started number
                     for job_msg_args in sorted(executing_jobs, key=lambda args: args['number']):
                         msg += clr("[{name} - {run_time}] ").format(**job_msg_args)
-                    msg_rhs = clr("[{0}/{1} Active | {2}/{3} Completed]").format(
+                    msg_rhs = clr("[{0}/{1} Active | {2}/{3} Completed | make: {4}]").format(
                         len(executing_jobs),
                         len(executors),
                         len(packages) if no_deps else len(completed_packages),
-                        total_packages
+                        total_packages,
+                        MakeJobServer.get_instance().num_running_jobs()
                     )
                     # Update title bar
                     sys.stdout.write("\x1b]2;[build] {0}/{1}\x07".format(
@@ -646,3 +648,4 @@ def build_isolated_workspace(
         # Ensure executors go down
         for x in range(jobs):
             job_queue.put(None)
+

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -595,12 +595,13 @@ def build_isolated_workspace(
                     # Print them in order of started number
                     for job_msg_args in sorted(executing_jobs, key=lambda args: args['number']):
                         msg += clr("[{name} - {run_time}] ").format(**job_msg_args)
-                    msg_rhs = clr("[{0}/{1} Active | {2}/{3} Completed | make: {4}]").format(
+                    msg_rhs = clr("[{0}/{1} Jobs][{2}/{3} Active Packages][{4}/{5} Completed]").format(
+                        MakeJobServer.get_instance().num_running_jobs(),
+                        MakeJobServer.get_instance().num_jobs,
                         len(executing_jobs),
                         len(executors),
                         len(packages) if no_deps else len(completed_packages),
-                        total_packages,
-                        MakeJobServer.get_instance().num_running_jobs()
+                        total_packages
                     )
                     # Update title bar
                     sys.stdout.write("\x1b]2;[build] {0}/{1}\x07".format(
@@ -648,4 +649,3 @@ def build_isolated_workspace(
         # Ensure executors go down
         for x in range(jobs):
             job_queue.put(None)
-

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -36,6 +36,8 @@ from catkin_tools.metadata import update_metadata
 
 from catkin_tools.resultspace import load_resultspace_environment
 
+from catkin_tools.make_jobserver import MakeJobServer
+
 from .color import clr
 
 from .common import get_build_type
@@ -85,6 +87,8 @@ def prepare_arguments(parser):
     add = build_group.add_argument
     add('--force-cmake', action='store_true', default=None,
         help='Runs cmake explicitly for each catkin package.')
+    add('--jobserver-limit', default=None,
+        help='Limit parallel job count through the internal GNU make job server (default is cpu count)')
     add('--no-install-lock', action='store_true', default=None,
         help='Prevents serialization of the install steps, which is on by default to prevent file install collisions')
 
@@ -179,6 +183,8 @@ def main(opts):
             log(clr("@!@{rf}Error:@| Unable to extend workspace from \"%s\": %s" %
                     (ctx.extend_path, exc.message)))
             return 1
+
+    jobserver = MakeJobServer(opts.jobserver_limit)
 
     # Display list and leave the filesystem untouched
     if opts.dry_run:


### PR DESCRIPTION
This is a proof-of-concept for #84.

To test it, try `catkin build --jobserver-limit 4` to limit the number of build tool processes to 4.

You can see the number of currently running make jobs in the lower right corner (`Make: X`).

I know the implementation is pretty ugly, but maybe this is a starting point for discussion.