### PR TITLE
Add transient hint to notifications

### DIFF
--- a/catkin_tools/notifications/impl.py
+++ b/catkin_tools/notifications/impl.py
@@ -44,7 +44,7 @@ def _notify_linux(title, msg):
     notify_send_exec = which('notify-send')
     if notify_send_exec is None:
         return
-    subprocess.Popen([notify_send_exec, '-i', icon_path, '-t', '2000', title, msg],
+    subprocess.Popen([notify_send_exec, '-i', icon_path, '-t', '2000', '--hint', 'int:transient:1', title, msg],
                      stdout=subprocess.PIPE,
                      stderr=subprocess.PIPE)
 


### PR DESCRIPTION
On gnome-shell, notifications are persistent by default, where the user needs to clear the notification explicitly. So we add a transient hint such that the notification doesn't stay in the notification area indefinitely.
