### PR TITLE
build: use -n for --dry-run shorthand, like git

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -61,7 +61,7 @@ def prepare_arguments(parser):
     add_context_args(parser)
     # Sub-commands
     add = parser.add_argument
-    add('--dry-run', '-d', action='store_true', default=False,
+    add('--dry-run', '-n', action='store_true', default=False,
         help='List the packages which will be built with the given arguments without building them.')
     # What packages to build
     pkg_group = parser.add_argument_group('Packages', 'Control which packages get built.')


### PR DESCRIPTION
Currently for the build verb `-d` is shorthand for `--dy-run`, but `-d` should be reserved for `--debug`'s shorthand, I propose using `-n` for `--dry-run`'s shorthand like `git` and `hg add` do.
