### PR TITLE
build: Adding support for spaces in args to build_env.sh by faking arrays

### DIFF
--- a/tests/integrated/test_build.py
+++ b/tests/integrated/test_build.py
@@ -42,3 +42,16 @@ def test_build_auto_init_one_pkg():
     assert_no_warnings(out)
     assert_workspace_initialized('.')
 
+@in_temporary_directory
+def test_build_eclipse():
+    cwd = os.getcwd()
+    source_space = os.path.join(cwd, 'src')
+    print("Creating source directory: %s" % source_space)
+    os.mkdir(source_space)
+    assert_cmd_success(['catkin', 'create', 'pkg', '--rosdistro', 'hydro', '-p', source_space, 'pkg_a'])
+    out = assert_cmd_success(['catkin', 'build', '--no-notify',
+        '--no-status', '--verbose', '--cmake-args', '-GEclipse CDT4 - Unix Makefiles'])
+    assert_no_warnings(out)
+    assert_workspace_initialized('.')
+    assert_files_exist(os.path.join(cwd, 'build', 'pkg_a'), ['.project', '.cproject'])
+


### PR DESCRIPTION
Also added unit test which essentially does:

``` sh
mkdir -p /tmp/eclipse_test/src
cd /tmp/eclipse_test
catkin create pkg --rosdistro hydro -p src pkg_a
catkin build --no-notify --no-status --verbose --cmake-args -GEclipse\ CDT4\ -\ Unix\ Makefiles
```

This addresses #49 and #74
