### PR TITLE
Handle case in which terminal width can't be read.

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -34,6 +34,7 @@ from .terminal_color import ColorMapper
 color_mapper = ColorMapper()
 clr = color_mapper.clr
 
+
 def get_tty_width():
     tty_size = os.popen('stty size', 'r').read().split()
     if len(tty_size) != 2:


### PR DESCRIPTION
Fixes the following error, that I got on an osx jenkins slave.

```
stty: stdin isn't a terminal
Creating build space directory, '/Users/slynen/workspace/minkindr/label/osx/build'
[build] Runtime: 0.0 seconds
Traceback (most recent call last):
  File "/usr/local/bin/catkin", line 9, in <module>
    load_entry_point('catkin-tools==0.2.0', 'console_scripts', 'catkin')()
  File "/Library/Python/2.7/site-packages/catkin_tools-0.2.0-py2.7.egg/catkin_tools/commands/catkin.py", line 198, in main
    sys.exit(args.main(args) or 0)
  File "/Library/Python/2.7/site-packages/catkin_tools-0.2.0-py2.7.egg/catkin_tools/verbs/catkin_build/cli.py", line 219, in main
    no_notify=opts.no_notify
  File "/Library/Python/2.7/site-packages/catkin_tools-0.2.0-py2.7.egg/catkin_tools/verbs/catkin_build/build.py", line 413, in build_isolated_workspace
    log(context.summary(summary_notes))
  File "/Library/Python/2.7/site-packages/catkin_tools-0.2.0-py2.7.egg/catkin_tools/context.py", line 396, in summary
    _, term_cols = os.popen('stty size', 'r').read().split()
ValueError: need more than 0 values to unpack
```
