### PR TITLE
config/build: adding whitelist/blacklist behavior

### DIFF
--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -51,6 +51,20 @@ def prepare_arguments(parser):
     add('--mkdirs', action='store_true', default=False,
         help='Create directories required by the configuration (e.g. source space) if they do not already exist.')
 
+    lists_group = parser.add_argument_group(
+        'Package Build Defaults', 'Packages to include or exclude from default build behavior.')
+    add = lists_group.add_mutually_exclusive_group().add_argument
+    add('--whitelist', metavar="PKG", dest='whitelist', nargs="+", required=False, type=str, default=None,
+        help='If the whitelist is non-empty, only the packages on the whitelist are built with a bare call'
+             ' to `catkin build`.')
+    add('--clear-whitelist', dest='whitelist', action='store_const', const=[], default=None,
+        help='Clear all packages from the whitelist.')
+    add = lists_group.add_mutually_exclusive_group().add_argument
+    add('--blacklist', metavar="PKG", dest='blacklist', nargs="+", required=False, type=str, default=None,
+        help='Packages on the blacklist are not built with a bare call to `catkin build`.')
+    add('--clear-blacklist', dest='blacklist', action='store_const', const=[], default=None,
+        help='Clear all packages from the blacklist.')
+
     spaces_group = parser.add_argument_group('Spaces', 'Location of parts of the catkin workspace.')
     add = spaces_group.add_mutually_exclusive_group().add_argument
     add('-s', '--source-space', default=None,

--- a/docs/config_summary.rst
+++ b/docs/config_summary.rst
@@ -29,6 +29,9 @@ display the standard configuration summary, as shown below:
     Additional Make Args:        None
     Additional catkin Make Args: None
     --------------------------------------------------------------
+    Whitelisted Packages:        None
+    Blacklisted Packages:        None
+    --------------------------------------------------------------
     Workspace configuration appears valid.
     --------------------------------------------------------------
 
@@ -73,6 +76,8 @@ Overview Section
 - **Additional CMake Args** -- Arguments to be passed to CMake during the *configuration* step for all packages to be built.
 - **Additional Make Args** -- Arguments to be passed to Make during the *build* step for all packages to be built.
 - **Additional catkin Make Args** -- Similar to **Additional Make Args** but only applies to Catkin packages.
+- **Package Whitelist** -- These are the packages that will be built with a bare call to ``catkin build``
+- **Package Blacklist** -- These are the packages that will *not* be built unless explicitly named
 
 Notes Section
 -------------

--- a/docs/verbs/catkin_build.rst
+++ b/docs/verbs/catkin_build.rst
@@ -69,6 +69,9 @@ packages ``catkin build`` will build, and in what order. This can be done with t
     Additional Make Args:        None
     Additional catkin Make Args: None
     --------------------------------------------------------------
+    Whitelisted Packages:        None
+    Blacklisted Packages:        None
+    --------------------------------------------------------------
     Workspace configuration appears valid.
     --------------------------------------------------------------
     Found '36' packages in 0.0 seconds.
@@ -254,6 +257,9 @@ space** and a **devel space** will be created:
     Additional CMake Args:       None
     Additional Make Args:        None
     Additional catkin Make Args: None
+    --------------------------------------------------------------
+    Whitelisted Packages:        None
+    Blacklisted Packages:        None
     --------------------------------------------------------------
     Workspace configuration appears valid.
     --------------------------------------------------------------

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -128,6 +128,9 @@ workspace. Suppose you wanted to extend a standard ROS system install like
     Additional Make Args:        None
     Additional catkin Make Args: None
     --------------------------------------------------------------
+    Whitelisted Packages:        None
+    Blacklisted Packages:        None
+    --------------------------------------------------------------
     Workspace configuration appears valid.
     --------------------------------------------------------------
 
@@ -138,6 +141,53 @@ workspace. Suppose you wanted to extend a standard ROS system install like
     $ source devel/setup.bash
     $ echo $CMAKE_PREFIX_PATH
     /tmp/path/to/my_catkin_ws:/opt/ros/hydro
+
+
+Whitelisting and Blacklisting Packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Packages can be added to a package *whitelist* or *blacklist* in order to
+change which packages get built. If the *whitelist*  is non-empty, then a call
+to ``catkin build`` with no specific package names will only build the packages
+on the *whitelist*. This means that you can still build packages not on the
+*whitelist*, but only if they are named explicitly or are dependencies of other
+whitelisted packages.
+
+To set the whitelist, you can call the following command:
+
+.. code-black:: text
+
+    catkin config --whitelist foo bar
+
+To clear the whitelist, you can use the ``--clear-whitelist`` option:
+
+.. code-block:: text
+
+    catkin config --clear-whitelist
+
+If the *blacklist* is non-empty, it will filter the packages to be built in all
+cases except where a given package is named explicitly. This means that blacklisted
+packages will not be built even if another package in the workspace depends on them.
+
+.. note::
+
+    Blacklisting a package does not remove it's build directory or build
+    products, it only pevents it from being rebuilt.
+
+To set the blacklist, you can call the following command:
+
+.. code-black:: text
+
+    catkin config --blacklist baz
+
+To clear the blacklist, you can use the ``--clear-blacklist`` option:
+
+.. code-block:: text
+
+    catkin config --clear-blacklist
+
+Note that you can still build packages on the blacklist and whitelist by
+passing their names to ``catkin build`` explicitly.
 
 Full Command-Line Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,6 +233,19 @@ Full Command-Line Interface
                             set by --extend.
       --mkdirs              Create directories required by the configuration (e.g.
                             source space) if they do not already exist.
+
+    Package Build Defaults:
+      Packages to include or exclude from default build behavior.
+
+      --whitelist PKG [PKG ...]
+                            If the whitelist is non-empty, only the packages on
+                            the whitelist are built with a bare call to `catkin
+                            build`.
+      --clear-whitelist     Clear all packages from the whitelist.
+      --blacklist PKG [PKG ...]
+                            Packages on the blacklist are not built with a bare
+                            call to `catkin build`.
+      --clear-blacklist     Clear all packages from the blacklist.
 
     Spaces:
       Location of parts of the catkin workspace.


### PR DESCRIPTION
`catkin_make` supports "whitelisting" packages with the `CATKIN_WHITELIST_PACKAGES` CMake variable. This PR adds these capabilities to `catkin config` command like so:

*Set packages on the whitelist:*
```
catkin config --whitelist foo bar
```
*Set packages on the blacklist:*
```
catkin config --blacklist foo bar
```

Example in #149, requested by @aghazi