### PR TITLE
build: GNU Make jobserver to prevent resource glut (make_job_server rebased on master)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
   - "3.3"
 install:
-  - pip install argparse catkin-pkg distribute PyYAML
+  - pip install argparse catkin-pkg distribute PyYAML psutil
   - pip install nose coverage flake8 --upgrade
 before_script:
   - sudo apt-get install cmake python-setuptools libgtest-dev build-essential

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -422,3 +422,8 @@ def find_enclosing_package(search_start_path=None, ws_path=None, warnings=None):
             break
 
     return None
+
+
+def version_tuple(v):
+    """Get an integer version tuple from a string."""
+    return tuple(map(int, (str(v).split("."))))

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -63,7 +63,7 @@ class Context(object):
                    'isolate_install',
                    'cmake_args',
                    'make_args',
-                   'internal_make_jobserver',
+                   'use_internal_make_jobserver',
                    'catkin_make_args',
                    'whitelist',
                    'blacklist']
@@ -176,7 +176,7 @@ class Context(object):
         isolate_install=False,
         cmake_args=None,
         make_args=None,
-        internal_make_jobserver=True,
+        use_internal_make_jobserver=True,
         catkin_make_args=None,
         space_suffix=None,
         whitelist=None,
@@ -208,8 +208,8 @@ class Context(object):
         :type cmake_args: list
         :param make_args: extra make arguments to be passed to make for each package
         :type make_args: list
-        :param internal_make_jobserver: true if this configuration should use an internal make jobserv
-        :type internal_make_jobserver: bool
+        :param use_internal_make_jobserver: true if this configuration should use an internal make jobserv
+        :type use_internal_make_jobserver: bool
         :param catkin_make_args: extra make arguments to be passed to make for each catkin package
         :type catkin_make_args: list
         :param space_suffix: suffix for build, devel, and install spaces which are not explicitly set.
@@ -249,7 +249,7 @@ class Context(object):
         # Handle additional cmake and make arguments
         self.cmake_args = cmake_args or []
         self.make_args = make_args or []
-        self.internal_make_jobserver = internal_make_jobserver
+        self.use_internal_make_jobserver = use_internal_make_jobserver
         self.catkin_make_args = catkin_make_args or []
 
         # List of packages in the workspace is set externally
@@ -381,7 +381,7 @@ class Context(object):
                 clr("@{cf}Additional CMake Args:@|       @{yf}{cmake_args}@|"),
                 clr("@{cf}Additional Make Args:@|        @{yf}{make_args}@|"),
                 clr("@{cf}Additional catkin Make Args:@| @{yf}{catkin_make_args}@|"),
-                clr("@{cf}Internal Make Job Server:@|    @{yf}{_Context__internal_make_jobserver}@|"),
+                clr("@{cf}Internal Make Job Server:@|    @{yf}{_Context__use_internal_make_jobserver}@|"),
             ],
             [
                 clr("@{cf}Whitelisted Packages:@|        @{yf}{whitelisted_packages}@|"),
@@ -614,14 +614,14 @@ class Context(object):
         self.__make_args = value
 
     @property
-    def internal_make_jobserver(self):
-        return self.__internal_make_jobserver
+    def use_internal_make_jobserver(self):
+        return self.__use_internal_make_jobserver
 
-    @internal_make_jobserver.setter
-    def internal_make_jobserver(self, value):
+    @use_internal_make_jobserver.setter
+    def use_internal_make_jobserver(self, value):
         if self.__locked:
             raise RuntimeError("Setting of context members is not allowed while locked.")
-        self.__internal_make_jobserver = value
+        self.__use_internal_make_jobserver = value
 
     @property
     def catkin_make_args(self):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -63,6 +63,7 @@ class Context(object):
                    'isolate_install',
                    'cmake_args',
                    'make_args',
+                   'internal_make_jobserver',
                    'catkin_make_args',
                    'whitelist',
                    'blacklist']
@@ -175,6 +176,7 @@ class Context(object):
         isolate_install=False,
         cmake_args=None,
         make_args=None,
+        internal_make_jobserver=True,
         catkin_make_args=None,
         space_suffix=None,
         whitelist=None,
@@ -206,6 +208,8 @@ class Context(object):
         :type cmake_args: list
         :param make_args: extra make arguments to be passed to make for each package
         :type make_args: list
+        :param internal_make_jobserver: true if this configuration should use an internal make jobserv
+        :type internal_make_jobserver: bool
         :param catkin_make_args: extra make arguments to be passed to make for each catkin package
         :type catkin_make_args: list
         :param space_suffix: suffix for build, devel, and install spaces which are not explicitly set.
@@ -245,6 +249,7 @@ class Context(object):
         # Handle additional cmake and make arguments
         self.cmake_args = cmake_args or []
         self.make_args = make_args or []
+        self.internal_make_jobserver = internal_make_jobserver
         self.catkin_make_args = catkin_make_args or []
 
         # List of packages in the workspace is set externally
@@ -376,6 +381,7 @@ class Context(object):
                 clr("@{cf}Additional CMake Args:@|       @{yf}{cmake_args}@|"),
                 clr("@{cf}Additional Make Args:@|        @{yf}{make_args}@|"),
                 clr("@{cf}Additional catkin Make Args:@| @{yf}{catkin_make_args}@|"),
+                clr("@{cf}Internal Make Job Server:@|    @{yf}{_Context__internal_make_jobserver}@|"),
             ],
             [
                 clr("@{cf}Whitelisted Packages:@|        @{yf}{whitelisted_packages}@|"),
@@ -606,6 +612,16 @@ class Context(object):
         if self.__locked:
             raise RuntimeError("Setting of context members is not allowed while locked.")
         self.__make_args = value
+
+    @property
+    def internal_make_jobserver(self):
+        return self.__internal_make_jobserver
+
+    @internal_make_jobserver.setter
+    def internal_make_jobserver(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__internal_make_jobserver = value
 
     @property
     def catkin_make_args(self):

--- a/catkin_tools/make_jobserver.py
+++ b/catkin_tools/make_jobserver.py
@@ -1,0 +1,134 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from os import pipe, write, close, unlink, read
+from multiprocessing import cpu_count
+from tempfile import mkstemp
+from subprocess import call, PIPE
+from termios import FIONREAD
+
+import fcntl
+import array
+
+# from .common import log
+
+job_server_instance = None
+
+
+class MakeJobServer:
+    """
+    This class implements a GNU make job server.
+    """
+
+    @staticmethod
+    def get_instance():
+        return job_server_instance
+
+    def __init__(self, num_jobs=None):
+        global job_server_instance
+        assert(not job_server_instance)
+        job_server_instance = self
+
+        if not num_jobs:
+            try:
+                num_jobs = cpu_count()
+            except NotImplementedError:
+                # log('Failed to determine the cpu_count, falling back to 1 jobs as the default.')
+                num_jobs = 1
+        else:
+            num_jobs = int(num_jobs)
+
+        self.num_jobs = num_jobs
+        self.pipe = pipe()
+
+        # Initialize the pipe with num_jobs tokens
+        for i in range(num_jobs):
+            write(self.pipe[1], b'+')
+
+        self.supported = self._testSupport()
+
+    def _testSupport(self):
+        """
+        Test if the system 'make' supports the job server implementation
+        """
+
+        fd, makefile = mkstemp()
+        write(fd, b'''
+all:
+\techo $(MAKEFLAGS) | grep -- '--jobserver-fds'
+''')
+        close(fd)
+
+        ret = call(['make', '-f', makefile, '-j2'], stdout=PIPE, stderr=PIPE)
+
+        unlink(makefile)
+        return (ret == 0)
+
+    def make_arguments(self):
+        """
+        Get required arguments for spawning child make processes
+        """
+
+        return ["--jobserver-fds=%d,%d" % self.pipe, "-j"]
+
+    def num_running_jobs(self):
+        """
+        Try to estimate the number of currently running jobs
+        """
+
+        try:
+            buf = array.array('i', [0])
+            if fcntl.ioctl(self.pipe[0], FIONREAD, buf) == 0:
+                return self.num_jobs - buf[0]
+        except NotImplementedError:
+            pass
+        except OSError:
+            pass
+
+        return self.num_jobs
+
+    def obtain(self):
+        """
+        Obtain a job server token. Be sure to call release() to avoid
+        deadlocks.
+        """
+
+        while True:
+            try:
+                token = read(self.pipe[0], 1)
+                return token
+            except OSError as e:
+                if e.errno == errno.EINTR:
+                    continue
+                else:
+                    raise
+
+    def release(self):
+        """
+        Release a job server token.
+        """
+
+        write(self.pipe[1], b'+')
+
+    def __enter__(self):
+        if self.supported:
+            self.obtain()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.supported:
+            self.release()
+        return False

--- a/catkin_tools/make_jobserver.py
+++ b/catkin_tools/make_jobserver.py
@@ -22,6 +22,7 @@ import array
 import fcntl
 import os
 import psutil
+import re
 import subprocess
 import time
 
@@ -33,108 +34,93 @@ all:
 '''
 
 
-class MakeJobServer:
-
+class _MakeJobServer:
     """
     This class implements a GNU make job server.
-
-    TODO:
-     - use os.getloadavg() to maintain server load
     """
 
+    # Singleton jobserver
     _singleton = None
 
-    @staticmethod
-    def get_instance(*args, **kwargs):
-        if not MakeJobServer._singleton:
-            MakeJobServer._singleton = MakeJobServer(*args, **kwargs)
-        elif len(args) > 0 or len(kwargs) > 0:
-            log('WARNING: Attempting to instantiate more than one jobserver!')
-
-        return MakeJobServer._singleton
-
-    def __init__(self, num_jobs=None, max_load=None, max_mem=None, enable=True):
+    def __init__(self, num_jobs=None, max_load=None, max_mem=None):
         """
         :param num_jobs: the maximum number of jobs available
         :param max_load: do not dispatch additional jobs if this system load
         value is exceeded
         :param max_mem: do not dispatch additional jobs if system physical
-        memory usage exceeds this value
-        """
-        assert(MakeJobServer._singleton is None)
-
-        if enable:
-            if not num_jobs:
-                try:
-                    num_jobs = cpu_count()
-                except NotImplementedError:
-                    log('@{yf}WARNING: Failed to determine the cpu_count, falling back to 1 jobs as the default.@|')
-                    num_jobs = 1
-            else:
-                num_jobs = int(num_jobs)
-
-            self.num_jobs = num_jobs
-            self.max_load = max_load
-            self.max_mem = max_mem
-            self.job_pipe = os.pipe()
-
-            # Initialize the pipe with num_jobs tokens
-            for i in range(num_jobs):
-                os.write(self.job_pipe[1], b'+')
-
-            # Check if the jobserver is supported
-            self.supported = self._testSupport()
-
-        if not enable or not self.supported:
-            log('@{yf}WARNING: Failed to determine the cpu_count, falling back to 1 jobs as the default.@|')
-            self.num_jobs = 0
-            self.job_pipe = None
-            self.supported = False
-
-
-    def _testSupport(self):
-        """
-        Test if the system 'make' supports the job server implementation
+        memory usage exceeds this value (see _set_max_mem for additional
+        documentation)
         """
 
-        fd, makefile = mkstemp()
-        os.write(fd, JOBSERVER_SUPPORT_MAKEFILE)
-        os.close(fd)
+        assert(_MakeJobServer._singleton is None)
 
-        ret = subprocess.call(['make', '-f', makefile, '-j2'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if not num_jobs:
+            try:
+                num_jobs = cpu_count()
+            except NotImplementedError:
+                log('@{yf}WARNING: Failed to determine the cpu_count, falling back to 1 jobs as the default.@|')
+                num_jobs = 1
+        else:
+            num_jobs = int(num_jobs)
 
-        os.unlink(makefile)
-        return (ret == 0)
+        self.num_jobs = num_jobs
+        self.max_load = max_load
+        self._set_max_mem(max_mem)
 
-    def make_arguments(self):
+        self.job_pipe = os.pipe()
+
+        # Initialize the pipe with num_jobs tokens
+        for i in range(num_jobs):
+            os.write(self.job_pipe[1], b'+')
+
+    def _set_max_mem(self, max_mem):
         """
-        Get required arguments for spawning child make processes
+        Set the maximum memory to keep instantiating jobs.
+
+        :param max_mem: String describing the maximum memory that can be used
+        on the system. It can either describe memory percentage or absolute
+        amount.  Use 'P%' for percentage or 'N' for absolute value in bytes,
+        'Nk' for kilobytes, 'Nm' for megabytes, and 'Ng' for gigabytes.
+        :type max_mem: str
         """
 
-        return ["--jobserver-fds=%d,%d" % self.job_pipe, "-j"] if self.supported else []
+        if max_mem is None:
+            self.max_mem = None
+            return
+        elif type(max_mem) is float or type(max_mem) is int:
+            mem_percent = max_mem
+        elif type(max_mem) is str:
+            m_percent = re.search('([0-9]+)\%', max_mem)
+            m_abs = re.search('([0-9]+)([kKmMgG]{0,1})', max_mem)
 
-    def num_running_jobs(self):
+            if m_percent is None and m_abs is None:
+                self.max_mem = None
+                return
+
+            if m_percent:
+                mem_percent = m_abs.group(1)
+            elif m_abs:
+                val = float(m_abs.group(1))
+                mag_symbol = m_abs.group(2)
+
+                total_mem = float(psutil.phymem_usage().total)
+
+                if mag_symbol == '':
+                    mag = 1.0
+                elif mag_symbol.lower() == 'k':
+                    mag = 1024.0
+                elif mag_symbol.lower() == 'm':
+                    mag = pow(1024.0, 2)
+                elif mag_symbol.lower() == 'g':
+                    mag = pow(1024.0, 3)
+
+                mem_percent = 100.0 * val * mag / total_mem
+
+        self.max_mem = max(0.0, min(100.0, float(mem_percent)))
+
+    def _obtain(self):
         """
-        Try to estimate the number of currently running jobs
-        """
-
-        if not self.supported:
-            return '?'
-
-        try:
-            buf = array.array('i', [0])
-            if fcntl.ioctl(self.job_pipe[0], FIONREAD, buf) == 0:
-                return self.num_jobs - buf[0]
-        except NotImplementedError:
-            pass
-        except OSError:
-            pass
-
-        return self.num_jobs
-
-    def obtain(self):
-        """
-        Obtain a job server token. Be sure to call release() to avoid
+        Obtain a job server token. Be sure to call _release() to avoid
         deadlocks.
         """
 
@@ -142,9 +128,8 @@ class MakeJobServer:
             # make sure we're observing load maximums
             if self.max_load is not None:
                 try:
-                    max_load = 8.0
                     load = os.getloadavg()
-                    if self.num_running_jobs() > 0 and load[1] > self.max_load:
+                    if jobserver_running_jobs() > 0 and load[1] > self.max_load:
                         time.sleep(0.01)
                         continue
                 except NotImplementedError:
@@ -153,7 +138,7 @@ class MakeJobServer:
             # make sure we're observing memory maximum
             if self.max_mem is not None:
                 mem_usage = psutil.phymem_usage()
-                if self.num_running_jobs() > 0 and mem_usage.percent > self.max_mem:
+                if jobserver_running_jobs() > 0 and mem_usage.percent > self.max_mem:
                     time.sleep(0.01)
                     continue
 
@@ -165,19 +150,139 @@ class MakeJobServer:
                 if e.errno != errno.EINTR:
                     raise
 
-    def release(self):
+    def _release(self):
         """
         Release a job server token.
         """
 
         os.write(self.job_pipe[1], b'+')
 
+
+class _MakeJob:
+    """
+    Context manager representing a jobserver job.
+    """
     def __enter__(self):
-        if self.supported:
-            self.obtain()
+        if _MakeJobServer._singleton is not None:
+            _MakeJobServer._singleton._obtain()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.supported:
-            self.release()
+        if _MakeJobServer._singleton is not None:
+            _MakeJobServer._singleton._release()
         return False
+
+
+def _test_support():
+    """
+    Test if the system 'make' supports the job server implementation.
+    """
+
+    fd, makefile = mkstemp()
+    os.write(fd, JOBSERVER_SUPPORT_MAKEFILE)
+    os.close(fd)
+
+    ret = subprocess.call(['make', '-f', makefile, '-j2'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    os.unlink(makefile)
+    return (ret == 0)
+
+
+def initialize_jobserver(*args, **kwargs):
+    """
+    Initialize the global GNU Make jobserver.
+
+    :param num_jobs: the maximum number of jobs available
+    :param max_load: do not dispatch additional jobs if this system load
+    value is exceeded
+    :param max_mem: do not dispatch additional jobs if system physical
+    memory usage exceeds this value
+    """
+
+    assert(_MakeJobServer._singleton is None)
+
+    # Check if the jobserver is supported
+    supported = _test_support()
+
+    if not supported:
+        _MakeJobServer._singleton = None
+        log('@{yf}WARNING: Make job server not supported. The number of Make '
+            'jobs may exceed the number of CPU cores.@|')
+        return
+
+    # Create the jobserver singleton
+    _MakeJobServer._singleton = _MakeJobServer(*args, **kwargs)
+
+
+def jobserver_job():
+    """
+    Get a job from the jobserver.
+
+    This is meant to be used with a context manager.
+    """
+    return _MakeJob()
+
+
+def jobserver_arguments():
+    """
+    Get required arguments for spawning child make processes.
+    """
+
+    if _MakeJobServer._singleton is not None:
+        return ["--jobserver-fds=%d,%d" % _MakeJobServer._singleton.job_pipe, "-j"]
+    else:
+        return []
+
+
+def jobserver_running_jobs():
+    """
+    Try to estimate the number of currently running jobs.
+    """
+
+    if _MakeJobServer._singleton is None:
+        return '?'
+
+    try:
+        buf = array.array('i', [0])
+        if fcntl.ioctl(_MakeJobServer._singleton.job_pipe[0], FIONREAD, buf) == 0:
+            return _MakeJobServer._singleton.num_jobs - buf[0]
+    except NotImplementedError:
+        pass
+    except OSError:
+        pass
+
+    return _MakeJobServer._singleton.num_jobs
+
+
+def jobserver_max_jobs():
+    """
+    Get the maximum number of jobs.
+    """
+
+    if _MakeJobServer._singleton is not None:
+        return _MakeJobServer._singleton.num_jobs
+    else:
+        return 0
+
+
+def jobserver_supported():
+    """
+    Returns true if the jobserver exists.
+    """
+    return _MakeJobServer._singleton is not None
+
+
+def set_jobserver_max_mem(max_mem):
+    """
+    Set the maximum memory to keep instantiating jobs.
+
+    :param max_mem: String describing the maximum memory that can be used on
+    the system. It can either describe memory percentage or absolute amount.
+    Use 'P%' for percentage or 'N' for absolute value in bytes, 'Nk' for
+    kilobytes, 'Nm' for megabytes, and 'Ng' for gigabytes.
+    :type max_mem: str
+    """
+
+    if _MakeJobServer._singleton:
+        _MakeJobServer._singleton._set_max_mem(max_mem)
+

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -55,6 +55,7 @@ from catkin_tools.common import log
 from catkin_tools.common import remove_ansi_escape
 from catkin_tools.common import terminal_width
 from catkin_tools.common import wide_log
+from catkin_tools.make_jobserver import MakeJobServer
 
 from .common import get_build_type
 
@@ -795,7 +796,9 @@ def build_isolated_workspace(
                     # Print them in order of started number
                     for job_msg_args in sorted(executing_jobs, key=lambda args: args['number']):
                         msg += clr("[{name} - {run_time}] ").format(**job_msg_args)
-                    msg_rhs = clr("[{0}/{1} Active | {2}/{3} Completed]").format(
+                    msg_rhs = clr("[{0}/{1} Jobs][{2}/{3} Active Packages][{4}/{5} Completed]").format(
+                        MakeJobServer.get_instance().num_running_jobs(),
+                        MakeJobServer.get_instance().num_jobs,
                         len(executing_jobs),
                         len(executors),
                         len(packages) if no_deps else len(completed_packages),

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -796,14 +796,24 @@ def build_isolated_workspace(
                     # Print them in order of started number
                     for job_msg_args in sorted(executing_jobs, key=lambda args: args['number']):
                         msg += clr("[{name} - {run_time}] ").format(**job_msg_args)
-                    msg_rhs = clr("[{0}/{1} Jobs][{2}/{3} Active Packages][{4}/{5} Completed]").format(
-                        MakeJobServer.get_instance().num_running_jobs(),
-                        MakeJobServer.get_instance().num_jobs,
-                        len(executing_jobs),
-                        len(executors),
-                        len(packages) if no_deps else len(completed_packages),
-                        total_packages
-                    )
+
+                    if MakeJobServer.get_instance().supported:
+                        msg_rhs = clr("[{0}/{1} Jobs][{2}/{3} Packages][{4}/{5} Completed]").format(
+                            MakeJobServer.get_instance().num_running_jobs(),
+                            MakeJobServer.get_instance().num_jobs,
+                            len(executing_jobs),
+                            len(executors),
+                            len(packages) if no_deps else len(completed_packages),
+                            total_packages
+                        )
+                    else:
+                        msg_rhs = clr("[{0}/{1} Packages][{2}/{3} Completed]").format(
+                            len(executing_jobs),
+                            len(executors),
+                            len(packages) if no_deps else len(completed_packages),
+                            total_packages
+                        )
+
                     # Update title bar
                     sys.stdout.write("\x1b]2;[build] {0}/{1}\x07".format(
                         len(packages) if no_deps else len(completed_packages),

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -55,7 +55,10 @@ from catkin_tools.common import log
 from catkin_tools.common import remove_ansi_escape
 from catkin_tools.common import terminal_width
 from catkin_tools.common import wide_log
-from catkin_tools.make_jobserver import MakeJobServer
+
+from catkin_tools.make_jobserver import jobserver_max_jobs
+from catkin_tools.make_jobserver import jobserver_running_jobs
+from catkin_tools.make_jobserver import jobserver_supported
 
 from .common import get_build_type
 
@@ -797,10 +800,10 @@ def build_isolated_workspace(
                     for job_msg_args in sorted(executing_jobs, key=lambda args: args['number']):
                         msg += clr("[{name} - {run_time}] ").format(**job_msg_args)
 
-                    if MakeJobServer.get_instance().supported:
+                    if jobserver_supported():
                         msg_rhs = clr("[{0}/{1} Jobs][{2}/{3} Packages][{4}/{5} Completed]").format(
-                            MakeJobServer.get_instance().num_running_jobs(),
-                            MakeJobServer.get_instance().num_jobs,
+                            jobserver_running_jobs(),
+                            jobserver_max_jobs(),
                             len(executing_jobs),
                             len(executors),
                             len(packages) if no_deps else len(completed_packages),

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -31,13 +31,14 @@ from catkin_tools.common import find_enclosing_package
 
 from catkin_tools.context import Context
 
+from catkin_tools.make_jobserver import set_jobserver_max_mem
+
 from catkin_tools.metadata import find_enclosing_workspace
+
 from catkin_tools.metadata import get_metadata
 from catkin_tools.metadata import update_metadata
 
 from catkin_tools.resultspace import load_resultspace_environment
-
-from catkin_tools.make_jobserver import MakeJobServer
 
 from .color import clr
 
@@ -145,6 +146,9 @@ the --save-config argument. To see the current config, use the
     add('--no-color', action='store_true', help=argparse.SUPPRESS)
     add('--force-color', action='store_true', help=argparse.SUPPRESS)
 
+    # Experimental args
+    add('--mem-limit', default=None, help=argparse.SUPPRESS)
+
     def status_rate_type(rate):
         rate = float(rate)
         if rate < 0:
@@ -224,7 +228,13 @@ def main(opts):
     ctx = Context.load(opts.workspace, opts.profile, opts, append=True)
 
     # Initialize the build configuration
-    make_args, makeflags, cli_flags, jobserver = configure_make_args(ctx.make_args, ctx.internal_make_jobserver)
+    make_args, makeflags, cli_flags, jobserver = configure_make_args(ctx.make_args, ctx.use_internal_make_jobserver)
+
+    # Set the jobserver memory limit
+    if jobserver and opts.mem_limit:
+        print(clr("@!@{pf}EXPERIMENTAL: limit memory to %s@|" % str(opts.mem_limit)))
+        set_jobserver_max_mem(opts.mem_limit)
+
     ctx.make_args = make_args
 
     # Load the environment of the workspace to extend

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -36,6 +36,8 @@ from catkin_tools.metadata import update_metadata
 
 from catkin_tools.resultspace import load_resultspace_environment
 
+from catkin_tools.make_jobserver import MakeJobServer
+
 from .color import clr
 
 from .common import get_build_type
@@ -115,6 +117,8 @@ the --save-config argument. To see the current config, use the
     add = build_group.add_argument
     add('--force-cmake', action='store_true', default=None,
         help='Runs cmake explicitly for each catkin package.')
+    add('--jobserver-limit', default=None,
+        help='Limit parallel job count through the internal GNU make job server (default is cpu count)')
     add('--no-install-lock', action='store_true', default=None,
         help='Prevents serialization of the install steps, which is on by default to prevent file install collisions')
 
@@ -229,7 +233,10 @@ def main(opts):
                     (ctx.extend_path, exc.message)))
             return 1
 
-    # Display list and leave the file system untouched
+    # Create a Make job server for limiting resource glut
+    jobserver = MakeJobServer(opts.jobserver_limit)
+
+    # Display list and leave the filesystem untouched
     if opts.dry_run:
         dry_run(ctx, opts.packages, opts.no_deps, opts.start_with)
         return

--- a/catkin_tools/verbs/catkin_build/executor.py
+++ b/catkin_tools/verbs/catkin_build/executor.py
@@ -22,7 +22,8 @@ from .color import colorize_cmake
 
 from catkin_tools.common import remove_ansi_escape
 from catkin_tools.runner import run_command
-from catkin_tools.make_jobserver import MakeJobServer
+
+from catkin_tools.make_jobserver import jobserver_job
 
 
 class ExecutorEvent(object):
@@ -106,8 +107,6 @@ class Executor(Thread):
         self.queue.put(ExecutorEvent(self.executor_id, 'exit', data, package_name))
 
     def run(self):
-        jobserver = MakeJobServer.get_instance()
-
         try:
             # Until exit
             while True:
@@ -125,7 +124,7 @@ class Executor(Thread):
                 job_has_failed = False
 
                 # Execute each command in the job
-                with jobserver:
+                with jobserver_job():
                     for command in self.current_job:
                         install_space_locked = False
                         if command.lock_install_space:

--- a/docs/verbs/catkin_build.rst
+++ b/docs/verbs/catkin_build.rst
@@ -332,6 +332,28 @@ done by passing the ``--this`` option to ``catkin build`` like the following:
     - roscpp_tutorials     (catkin)
     Total packages: 1
 
+Controlling the Number of Build Jobs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default ``catkin build`` on a computer with ``N`` cores will build up to
+``N`` packages in parallel and will distribute ``N`` ``make`` jobs among them
+using an internal jobserver. If your platform doesn't support jobserver
+scheduling, ``catkin build`` will pass ``-jN -lN`` to ``make`` for each package.
+
+You can control the maximum number of packages allowed to build in parallel by
+using the ``-p`` or ``--parallel-packages`` option and you can change the
+number of ``make`` jobs available with the ``-j`` or ``--jobs`` option.
+
+By default, these jobs options aren't passed to the underlying ``make``
+command. To disable the jobserver, you can use the ``--no-jobserver`` option, and
+you can pass flags directly to ``make`` with the ``--make-args`` option.
+
+.. note::
+
+    Jobs flags (``-jN`` and/or ``-lN``) can be passed directly to ``make`` by
+    giving them to ``catkin build``, but other ``make`` arguments need to be
+    passed to the ``--make-args`` option.
+
 Controlling Command-Line Output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -433,22 +455,6 @@ well as the output of each build command in a block, once it finishes:
     The printing of these command outputs maybe be interleaved with commands
     from other package builds if more than one package is being built at the
     same time.
-
-By default ``catkin build`` will build up to ``N`` packages in parallel and
-pass ``-jN -lN`` to ``make`` where ``N`` is the number of cores in your
-computer.
-
-You can change the number of packages allowed to build in parallel
-by using the ``-p`` or ``--parallel-jobs`` option and you can change the jobs
-flags given to ``make`` by passing them directly to ``catkin build``, i.e.
-``catkin build -j1`` will result in ``make -j1 ...`` getting called to build
-the packages.
-
-.. note::
-
-    Jobs flags (``-jN`` and/or ``-lN``) can be passed directly to ``make`` by
-    giving them to ``catkin build``, but other ``make`` arguments need to be
-    passed to the ``--make-args`` option.
 
 If you want to see the output from commands streaming to the screen, then you
 can use the ``-i`` or ``--interleave`` option.  This option will cause the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml
-psutil
 catkin_pkg
 setuptools
 sphinxcontrib-ansi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyyaml
+psutil
 catkin_pkg
 setuptools
 sphinxcontrib-ansi


### PR DESCRIPTION
This is a rebase and extension of @xqms's jobserver prototype in PR #85 which was created to fix #84. Without the jobserver, `catkin build` will use too many resources on machines with multiple cores.

Behavior using this PR:
- `catkin build --no-jobserver` -- current behavior (maxes out all jobs for all packages unless using another jobserver like distcc)
- `catkin build` -- build using the jobserver and as many jobs as CPUs
- `catkin build --jobserver` -- explicit version of the line above
- `catkin build -jN`-- build using the jobserver and `N` jobs
- `MAKEFLAGS="-jN" catkin build`-- build using the jobserver and `N` jobs
- `catkin config --no-jobserver` -- disable the jobserver for future builds
- `catkin build -lV` -- don't create more than one job at a time if the system load is greater than `V`
- `catkin build --mem-limit P` -- don't create more than one job at a time if more than `P`% of the system memory is used

Outstanding issues:
- [x] The jobserver behavior isn't documented
- [x] The status line reads `?/0 Jobs` when the jobserver is disabled, it should display something friendlier
- [x] change `internal_make_jobserver` switches `use_internal_make_jobserver`
 - https://github.com/catkin/catkin_tools/pull/155/files#r26704312
 - https://github.com/catkin/catkin_tools/pull/155/files#r26705185
- [x] [document `configure_make_args`](https://github.com/catkin/catkin_tools/pull/155/files#r26703936)
- [x] clean up jobserver API
 - [checking support](https://github.com/catkin/catkin_tools/pull/155/files#r26704509)
- [x] make `psutil` an optional dependency, and only load it if the memory control options are used

Future work:
- The number of jobs (`-jN`) and the number of packages (`-pM`) are still decoupled. The jobserver will limit the number of `Make` instances, but maybe this is ok?
- The current internal jobserver implementation does not monitor load or memory usage. These would be good arguments to support.