### PR TITLE
color: moving color args out of build verb and into main program args

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -24,13 +24,10 @@ from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.argument_parsing import add_cmake_and_make_and_catkin_make_args
 
 from catkin_tools.common import format_time_delta
-from catkin_tools.common import is_tty
 from catkin_tools.common import log
 from catkin_tools.common import find_enclosing_package
 
 from catkin_tools.context import Context
-
-from catkin_tools.terminal_color import set_color
 
 from catkin_tools.metadata import get_metadata
 from catkin_tools.metadata import update_metadata
@@ -127,12 +124,6 @@ the --save-config argument. To see the current config, use the
 
     # Behavior
     behavior_group = parser.add_argument_group('Interface', 'The behavior of the command-line interface.')
-    color_control_group = behavior_group.add_mutually_exclusive_group()
-    add = color_control_group.add_argument
-    add('--force-color', action='store_true', default=False,
-        help='Forces catkin build to output in color, even when the terminal does not appear to support it.')
-    add('--no-color', action='store_true', default=False,
-        help='Forces catkin build to not use color in the output, regardless of the detect terminal type.')
     add = behavior_group.add_argument
     add('--verbose', '-v', action='store_true', default=False,
         help='Print output from commands in ordered blocks once the command finishes.')
@@ -144,6 +135,10 @@ the --save-config argument. To see the current config, use the
         help='Adds a build summary to the end of a build; defaults to on with --continue-on-failure, off otherwise')
     add('--no-summarize', '--no-summary', action='store_false', dest='summarize',
         help='explicitly disable the end of build summary')
+
+    # Deprecated args now handled by main catkin command
+    add('--no-color', action='store_true', help=argparse.SUPPRESS)
+    add('--force-color', action='store_true', help=argparse.SUPPRESS)
 
     def status_rate_type(rate):
         rate = float(rate)
@@ -212,9 +207,6 @@ def main(opts):
 
     if opts.no_deps and not opts.packages:
         sys.exit("With --no-deps, you must specify packages to build.")
-
-    if opts.no_color or not opts.force_color and not is_tty(sys.stdout):
-        set_color(False)
 
     # Load the context
     ctx = Context.Load(opts.workspace, opts.profile, opts)

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -85,6 +85,15 @@ Blow away the build, devel, and install spaces (if they exist):
 ... or just delete the build directories for packages which have been disabled or removed:
   - ``catkin clean --orphans``
 
+Controlling Color Display
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable colors when building in a shell that doesn't support it (like IDEs):
+  - ``catkin --no-color build``
+
+... or enable it for shells that don't know they support it:
+  - ``catkin --force-color build``
+
 Profile Cookbook
 ^^^^^^^^^^^^^^^^
 

--- a/docs/verbs/catkin_build.rst
+++ b/docs/verbs/catkin_build.rst
@@ -611,8 +611,7 @@ Full Command-Line Interface
                         [--cmake-args ARG [ARG ...] | --no-cmake-args]
                         [--make-args ARG [ARG ...] | --no-make-args]
                         [--catkin-make-args ARG [ARG ...] | --no-catkin-make-args]
-                        [--force-color] [--verbose] [--interleave-output]
-                        [--no-status] [--no-notify]
+                        [--verbose] [--interleave-output] [--no-status] [--no-notify]
                         [PKGNAME [PKGNAME ...]]
 
     Build one or more packages in a catkin workspace. This invokes `CMake`,
@@ -687,8 +686,6 @@ Full Command-Line Interface
     Interface:
       The behavior of the command-line interface.
 
-      --force-color         Forces catkin build to output in color, even when the
-                            terminal does not appear to support it.
       --verbose, -v         Print output from commands in ordered blocks once the
                             command finishes.
       --interleave-output, -i


### PR DESCRIPTION
There are now a bunch of subcommands in `catkin_tools` which generate color, so this moves the actual processing of these arguments into the main `catkin` command. Note that the arguments still exist in the `catkin build` verb, but they are hidden.