### PR TITLE
verbs: adding find verb to get workspace paths

### DIFF
--- a/catkin_tools/verbs/catkin_find/__init__.py
+++ b/catkin_tools/verbs/catkin_find/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cli import main
+from .cli import prepare_arguments
+
+# This describes this command to the loader
+description = dict(
+    verb='find',
+    description="Get the paths to various locations in a workspace.",
+    main=main,
+    prepare_arguments=prepare_arguments,
+)

--- a/catkin_tools/verbs/catkin_find/cli.py
+++ b/catkin_tools/verbs/catkin_find/cli.py
@@ -1,0 +1,140 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import sys
+
+from catkin_pkg.packages import find_packages
+
+from catkin_tools.argument_parsing import add_context_args
+
+from catkin_tools.context import Context
+
+from catkin_tools.metadata import find_enclosing_workspace
+
+from catkin_tools.terminal_color import ColorMapper
+
+color_mapper = ColorMapper()
+clr = color_mapper.clr
+
+
+def prepare_arguments(parser):
+
+    add_context_args(parser)
+
+    # Behavior
+    behavior_group = parser.add_argument_group('Behavior')
+    add = behavior_group.add_argument
+    add('-e', '--existing-only', action='store_true',
+        help="Only print paths to existing directories.")
+    add('-r', '--relative', action='store_true',
+        help="Print relative paths instead of the absolute paths.")
+
+    # Path options
+    dir_group = parser.add_argument_group(
+        'Sub-Space Options',
+        'Get the absolute path to one of the following locations in the given '
+        'workspace with the given profile.')
+    dir_group_mut = dir_group.add_mutually_exclusive_group()
+    add = dir_group_mut.add_argument
+    add('-s', '--src', dest='space', action='store_const', const='src',
+        help="Get the path to the source space.")
+    add('-b', '--build', dest='space', action='store_const', const='build',
+        help="Get the path to the build space.")
+    add('-d', '--devel', dest='space', action='store_const', const='devel',
+        help="Get the path to the devel space.")
+    add('-i', '--install', dest='space', action='store_const', const='install',
+        help="Get the path to the install space.")
+
+    pkg_group = parser.add_argument_group(
+        'Package Directories',
+        "Get the absolute path to package directories in the given workspace "
+        "and sub-space. By default this will output paths in the workspace's "
+        "source space. If the -b (--build) flag is given, it will output the "
+        "path to the package's build directory. If the -d or -i (--devel or "
+        "--install) flags are given, it will output the path to the package's "
+        "share directory in that space.")
+    add = pkg_group.add_argument
+    add('package', metavar='PACKAGE', nargs='?',
+        help="The name of a package to find.")
+
+    return parser
+
+
+def main(opts):
+
+    # Initialize dictionary version of opts namespace
+    opts_vars = vars(opts) if opts else {}
+
+    # Get the workspace (either the given directory or the enclosing ws)
+    workspace_hint = opts_vars.get('workspace', None) or os.getcwd()
+    workspace = find_enclosing_workspace(workspace_hint)
+
+    if not workspace:
+        print(clr("@{rf}ERROR: No workspace found containing '%s'@|" % workspace_hint), file=sys.stderr)
+        sys.exit(1)
+
+    # Load the context to get the subspaces
+    ctx = Context.load(workspace, opts.profile, opts, load_env=False)
+
+    path = None
+
+    if opts.space:
+        # Get the subspace
+        if opts.space == 'src':
+            path = ctx.source_space_abs
+        elif opts.space == 'build':
+            path = ctx.build_space_abs
+        elif opts.space == 'devel':
+            path = ctx.devel_space_abs
+        elif opts.space == 'install':
+            path = ctx.install_space_abs
+
+    if opts.package:
+        # Get the path to the given package
+        path = path or ctx.source_space_abs
+        if opts.space == 'build':
+            path = os.path.join(path, opts.package)
+        elif opts.space in ['devel', 'install']:
+            path = os.path.join(path, 'share', opts.package)
+        else:
+            try:
+                packages = find_packages(path, warnings=[])
+                catkin_package = [pkg_path for pkg_path, p in packages.items() if p.name == opts.package]
+                if catkin_package:
+                    path = os.path.join(path, catkin_package[0])
+                else:
+                    print(clr("@{rf}ERROR: Could not find a package named '%s' in path '%s'@|" %
+                              (opts.package, path)), file=sys.stderr)
+                    sys.exit(2)
+            except RuntimeError as e:
+                print(clr('@{rf}ERROR: %s@|' % str(e)), file=sys.stderr)
+                sys.exit(1)
+    elif not opts.space:
+        # Get the path to the workspace root
+        path = workspace
+
+    # Check if the path exists
+    if opts.existing_only and not os.path.exists(path):
+        print(clr("@{rf}ERROR: Requested path '%s' does not exist.@|" % path), file=sys.stderr)
+        sys.exit(1)
+
+    # Make the path relative if desired
+    if opts.relative:
+        path = os.path.relpath(path, os.getcwd())
+
+    # Print the path
+    print(path)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Catkin Command Line Tools
    verbs/catkin_clean
    verbs/catkin_config
    verbs/catkin_create
+   verbs/catkin_find
    verbs/catkin_init
    verbs/catkin_list
    verbs/catkin_profile

--- a/docs/verbs/catkin_find.rst
+++ b/docs/verbs/catkin_find.rst
@@ -1,0 +1,48 @@
+``catkin find`` -- Find Workspace Locations
+===========================================
+
+The ``find`` verb can be used to find important locations in the workspace such as
+the active ``source``, ``build``, ``devel``, and ``install`` spaces, and package
+directories in the workspace.
+
+Full Command-Line Interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+    usage: catkin find [-h] [--workspace WORKSPACE] [--profile PROFILE] [-e] [-r]
+                       [-s | -b | -d | -i]
+                       [PACKAGE]
+
+    Get the paths to various locations in a workspace.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --workspace WORKSPACE, -w WORKSPACE
+                            The path to the catkin_tools workspace or a directory
+                            contained within it (default: ".")
+      --profile PROFILE     The name of a config profile to use (default: active
+                            profile)
+
+    Behavior:
+      -e, --existing-only   Only print paths to existing directories.
+      -r, --relative        Print relative paths instead of the absolute paths.
+
+    Sub-Space Options:
+      Get the absolute path to one of the following locations in the given
+      workspace with the given profile.
+
+      -s, --src             Get the path to the source space.
+      -b, --build           Get the path to the build space.
+      -d, --devel           Get the path to the devel space.
+      -i, --install         Get the path to the install space.
+
+    Package Directories:
+      Get the absolute path to package directories in the given workspace and
+      sub-space. By default this will output paths in the workspace's source
+      space. If the -b (--build) flag is given, it will output the path to the
+      package's build directory. If the -d or -i (--devel or --install) flags
+      are given, it will output the path to the package's share directory in
+      that space.
+
+      PACKAGE               The name of a package to find.

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             'clean = catkin_tools.verbs.catkin_clean:description',
             'config = catkin_tools.verbs.catkin_config:description',
             'create = catkin_tools.verbs.catkin_create:description',
+            'find = catkin_tools.verbs.catkin_find:description',
             'init = catkin_tools.verbs.catkin_init:description',
             'list = catkin_tools.verbs.catkin_list:description',
             'profile = catkin_tools.verbs.catkin_profile:description',


### PR DESCRIPTION
@k-okada 

With this PR, calling this shell function from within a directory will source its devel space:

```bash
function source_devel() {
  source $(catkin find --devel)/setup.bash
}
```

```zsh
function source_devel() {
  source $(catkin find --devel)/setup.zsh
}
```

`cd` to a package in the workspace, regardless of `build_type` (see #143)

```bash
function ccd() {
  cd $(catkin find --src $1)
}
```