### PR TITLE
completion: adding bash (zsh) completion

### DIFF
--- a/completion/catkin_tools-completion.bash
+++ b/completion/catkin_tools-completion.bash
@@ -1,0 +1,109 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ZSH support
+if [[ -n ${ZSH_VERSION-} ]]; then
+  autoload -U +X bashcompinit && bashcompinit
+fi
+
+# TODO:
+# - parse --workspace and --profile options in order to complete outside of cwd
+# - autocomplete build options
+
+_catkin()
+{
+  local cur prev catkin_verbs catkin_opts
+
+  COMPREPLY=()
+
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD-1]}
+
+  # complete to the following verbs
+  catkin_verbs="build clean config create init list profile"
+
+  # complete to verbs ifany of these are the previous word
+  catkin_opts="--force-color --no-color --test-colors"
+
+  # complete popular catkin build options
+  catkin_build_opts="--dry-run --this --no-deps --continue-on-failure --force-cmake --verbose --summarize --no-notify"
+
+  # complete popular catkin clean options
+  catkin_clean_opts="--all --build --devel --install --cmake-cache --setup-files --orphans"
+
+  # complete popular catkin config options
+  catkin_config_opts="--init --extend --no-extend --cmake-args --make-args --catkin-make-args --space-suffix"
+
+  # complete popular catkin create options
+  catkin_create_pkg_opts="--version --license --maintainer --author --description --catkin-deps --system-deps --boost-components"
+
+  # complete catkin profile subcommands
+  catkin_profile_args="add list remove rename set"
+
+  if [[ ${COMP_CWORD} -eq 1 || ${catkin_opts} == *${prev}* ]] ; then
+    COMPREPLY=($(compgen -W "${catkin_verbs}" -- ${cur}))
+  else
+    if [[ "${COMP_WORDS[@]}" == *" build"* ]] ; then
+      if [[ ${cur} == -* ]]; then
+        COMPREPLY=($(compgen -W "${catkin_build_opts}" -- ${cur}))
+      else
+        COMPREPLY=($(compgen -W "$(catkin --no-color list --unformatted --quiet)" -- ${cur}))
+      fi
+    elif [[ "${COMP_WORDS[@]}" == *" config"* ]] ; then
+      COMPREPLY=($(compgen -W "${catkin_config_opts}" -- ${cur}))
+    elif [[ "${COMP_WORDS[@]}" == *" clean"* ]] ; then
+      COMPREPLY=($(compgen -W "${catkin_clean_opts}" -- ${cur}))
+    elif [[ "${COMP_WORDS[@]}" == *" create"* ]] ; then
+      if [[ "${COMP_WORDS[@]}" == *" pkg"* ]] ; then
+        COMPREPLY=($(compgen -W "${catkin_create_pkg_opts}" -- ${cur}))
+      else
+        COMPREPLY=($(compgen -W "pkg" -- ${cur}))
+      fi
+    elif [[ "${COMP_WORDS[@]}" == *" profile"* ]] ; then
+      case ${prev} in
+        profile)
+          COMPREPLY=($(compgen -W "${catkin_profile_args}" -- ${cur}))
+          ;;
+        set)
+          COMPREPLY=($(compgen -W "$(catkin --no-color profile list --unformatted)" -- ${cur}))
+          ;;
+        rename)
+          COMPREPLY=($(compgen -W "$(catkin --no-color profile list --unformatted)" -- ${cur}))
+          ;;
+        remove)
+          COMPREPLY=($(compgen -W "$(catkin --no-color profile list --unformatted)" -- ${cur}))
+          ;;
+        *)
+          COMPREPLY=()
+          ;;
+      esac
+    else
+      case ${prev} in
+        init)
+          COMPREPLY=()
+          ;;
+        list)
+          COMPREPLY=()
+          ;;
+        *)
+          COMPREPLY=()
+          ;;
+      esac
+    fi
+  fi
+
+  return 0
+}
+
+complete -F _catkin catkin

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,16 @@ from setuptools import setup
 from setuptools import find_packages
 
 
+# Setup installation dependencies
 install_requires = [
     'catkin-pkg >= 0.2.8',
     'setuptools',
     'PyYAML',
 ]
-
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     install_requires.append('argparse')
 
+# Figure out the resources that need to be installed
 this_dir = os.path.abspath(os.path.dirname(__file__))
 osx_resources_path = os.path.join(
     this_dir,
@@ -29,6 +30,21 @@ src_path = os.path.join(this_dir, 'catkin_tools')
 osx_notification_resources = [os.path.relpath(x, src_path)
                               for x in osx_notification_resources]
 
+# Figure out where to install the data_files
+data_files = []
+import argparse
+parser = argparse.ArgumentParser(description="shouldn't see this")
+parser.add_argument('--prefix')
+opts, _ = parser.parse_known_args(list(sys.argv))
+if opts.prefix and opts.prefix == '/usr':
+    data_files.append((
+        '/etc/bash_completion.d',
+        ['catkin_tools-completion.sh']))
+else:
+    data_files.append((
+        os.path.join(sys.prefix, 'etc/bash_completion.d'),
+        ['catkin_tools-completion.sh']))
+
 setup(
     name='catkin_tools',
     version='0.2.2',
@@ -38,6 +54,7 @@ setup(
             'notifications/resources/linux/catkin_icon.png',
         ] + osx_notification_resources
     },
+    data_files=data_files,
     install_requires=install_requires,
     author='William Woodall',
     author_email='william@osrfoundation.org',

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ opts, _ = parser.parse_known_args(list(sys.argv))
 if opts.prefix and opts.prefix == '/usr':
     data_files.append((
         '/etc/bash_completion.d',
-        ['catkin_tools-completion.sh']))
+        ['completion/catkin_tools-completion.bash']))
 else:
     data_files.append((
         os.path.join(sys.prefix, 'etc/bash_completion.d'),
-        ['catkin_tools-completion.sh']))
+        ['completion/catkin_tools-completion.bash']))
 
 setup(
     name='catkin_tools',


### PR DESCRIPTION
**NOTE: Depends on #190 See [cli-completion-full](https://github.com/jbohren-forks/catkin_tools/tree/cli-completion-full) for the integrated branch**

Completes:

- `catkin [--CATKIN-OPTS...] <tab>` completes to all builtin verbs
- `catkin [--CATKIN-OPTS...] build [--BUILD-OPTS...] <tab>` completes to package names given by `catkin list`
- `catkin [--CATKIN-OPTS...] build [--BUILD-OPTS...] -<tab>` completes to `--dry-run --this --no-deps --continue-on-failure --force-cmake --verbose --summarize --no-notify`
- `catkin create <tab>` completes to `catkin create` sub-commands
- `catkin create pkg <tab>` completes to `catkin create pkg` optional arguments
- `catkin profile <tab>` completes to `catkin profile` sub-commands
- `catkin profile [set rename remove] <tab>` completes to existing profiles

***Note:*** If you want to use them in zsh, you still need to source the bash file.

Fixes #15