### PR TITLE
Fixing Bug with CMake argument parsing

### DIFF
--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -116,7 +116,7 @@ def _extract_cmake_and_make_arguments(args, extract_catkin_make):
         if splitter_name not in args:
             return args, None
         start_index = args.index(splitter_name)
-        end_index = args.index('--', start_index + 1) if '--' in args else None
+        end_index = args.index('--', start_index + 1) if '--' in args else (len(args) - 1)
 
         if end_index:
             return args[0:index] + args[end_index + 1:], args[index + 1:end_index]


### PR DESCRIPTION
This fixes the bug caused by ignoring of the arguments passed to cmake args to be ignored