### PR TITLE
context: adding append/remove args option

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -73,7 +73,7 @@ class Context(object):
         'space_suffix']
 
     @classmethod
-    def Load(cls, workspace_hint=None, profile=None, opts=None, strict=False, append=False):
+    def load(cls, workspace_hint=None, profile=None, opts=None, strict=False, append=False, remove=False):
         """Load a context from a given workspace and profile with optional modifications.
 
         This function will try to load a given context from the specified
@@ -97,6 +97,8 @@ class Context(object):
         :type strict: bool
         :param append: Appends any list-type opts to existing opts
         :type append: bool
+        :param remove: Removes any list-type opts from existing opts
+        :type remove: bool
 
         :returns: A potentially valid Context object constructed from the given arguments
         :rtype: Context
@@ -132,8 +134,14 @@ class Context(object):
         # Only update context args with given opts which are not none
         for (k, v) in opts_vars.items():
             if k in Context.KEYS and v is not None:
-                if append and type(context_args.get(k, None)) is list and type(v) is list:
-                    context_args[k] += v
+                # Handle list-type arguments with append/remove functionality
+                if type(context_args.get(k, None)) is list and type(v) is list:
+                    if append:
+                        context_args[k] += v
+                    elif remove:
+                        context_args[k] = [w for w in context_args[k] if w not in v]
+                    else:
+                        context_args[k] = v
                 else:
                     context_args[k] = v
 
@@ -141,7 +149,7 @@ class Context(object):
         return Context(**context_args)
 
     @classmethod
-    def Save(cls, context):
+    def save(cls, context):
         """Save a context in the associated workspace and profile."""
         metadata.update_metadata(
             context.workspace,

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -212,7 +212,7 @@ def main(opts):
         sys.exit("With --no-deps, you must specify packages to build.")
 
     # Load the context
-    ctx = Context.Load(opts.workspace, opts.profile, opts, append=True)
+    ctx = Context.load(opts.workspace, opts.profile, opts, append=True)
 
     # Load the environment of the workspace to extend
     if ctx.extend_path is not None:
@@ -243,7 +243,7 @@ def main(opts):
 
     # Save the context as the configuration
     if opts.save_config:
-        Context.Save(ctx)
+        Context.save(ctx)
 
     start = time.time()
     try:

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -85,7 +85,7 @@ def main(opts):
     needs_force = False
 
     # Load the context
-    ctx = Context.Load(opts.workspace, opts.profile, opts, strict=True)
+    ctx = Context.load(opts.workspace, opts.profile, opts, strict=True)
 
     if not ctx:
         if not opts.workspace:

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -37,6 +37,13 @@ def prepare_arguments(parser):
     # Workspace / profile args
     add_context_args(parser)
 
+    behavior_group = parser.add_argument_group('Behavior', 'Options affecting argument handling.')
+    add = behavior_group.add_mutually_exclusive_group().add_argument
+    add('--append-args', '-a', action='store_true', default=False,
+        help='For list-type arguments, append elements.')
+    add('--remove-args', '-r', action='store_true', default=False,
+        help='For list-type arguments, remove elements.')
+
     context_group = parser.add_argument_group('Workspace Context', 'Options affecting the context of the workspace.')
     add = context_group.add_argument
     add('--init', action='store_true', default=False,
@@ -134,7 +141,12 @@ def main(opts):
 
         # Try to find a metadata directory to get context defaults
         # Otherwise use the specified directory
-        context = Context.Load(opts.workspace, opts.profile, opts)
+        context = Context.load(
+            opts.workspace,
+            opts.profile,
+            opts,
+            append=opts.append_args,
+            remove=opts.remove_args)
 
         do_init = opts.init or not no_action
         summary_notes = []
@@ -143,7 +155,7 @@ def main(opts):
             summary_notes.append(clr('@!@{cf}Initialized new catkin workspace in `%s`@|' % context.workspace))
 
         if context.initialized() or do_init:
-            Context.Save(context)
+            Context.save(context)
 
         if opts.mkdirs and not context.source_space_exists():
             os.makedirs(context.source_space_abs)

--- a/catkin_tools/verbs/catkin_init/cli.py
+++ b/catkin_tools/verbs/catkin_init/cli.py
@@ -38,7 +38,7 @@ def prepare_arguments(parser):
 def main(opts):
     try:
         # Load a context with initialization
-        ctx = Context.Load(opts.workspace, strict=True)
+        ctx = Context.load(opts.workspace, strict=True)
 
         # Initialize the workspace if necessary
         if ctx:
@@ -50,7 +50,7 @@ def main(opts):
                 opts.workspace or os.getcwd(),
                 opts.reset)
 
-        ctx = Context.Load(opts.workspace)
+        ctx = Context.load(opts.workspace)
         print(ctx.summary())
 
     except IOError as exc:

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -97,7 +97,7 @@ def list_profiles(profiles, active_profile):
 def main(opts):
     try:
         # Load a context with initialization
-        ctx = Context.Load(opts.workspace)
+        ctx = Context.load(opts.workspace)
 
         if not ctx.initialized():
             print("A catkin workspace must be initialized before profiles can be managed.")
@@ -120,21 +120,21 @@ def main(opts):
                     return 1
             if opts.copy_active:
                 ctx.profile = opts.name
-                Context.Save(ctx)
+                Context.save(ctx)
                 print(clr('[profile] Created a new profile named @{cf}%s@| '
                           'based on active profile @{cf}%s@|' % (opts.name, active_profile)))
             elif opts.copy:
                 if opts.copy in profiles:
-                    new_ctx = Context.Load(opts.workspace, profile=opts.copy)
+                    new_ctx = Context.load(opts.workspace, profile=opts.copy)
                     new_ctx.profile = opts.name
-                    Context.Save(new_ctx)
+                    Context.save(new_ctx)
                     print(clr('[profile] Created a new profile named @{cf}%s@| '
                               'based on profile @{cf}%s@|' % (opts.name, opts.copy)))
                 else:
                     print(clr('[profile] @{rf}A profile with this name does not exist: %s@|' % opts.copy))
             else:
                 new_ctx = Context(workspace=ctx.workspace, profile=opts.name)
-                Context.Save(new_ctx)
+                Context.save(new_ctx)
                 print(clr('[profile] Created a new profile named @{cf}%s@| with default settings.' % (opts.name)))
 
             profiles = get_profile_names(ctx.workspace)
@@ -168,7 +168,7 @@ def main(opts):
                                   'overwrite.' % (opts.new_name)))
                         return 1
                 ctx.profile = opts.new_name
-                Context.Save(ctx)
+                Context.save(ctx)
                 remove_profile(ctx.workspace, opts.current_name)
                 if opts.current_name == active_profile:
                     set_active_profile(ctx.workspace, opts.new_name)

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -23,6 +23,26 @@ the root of the workspace. Doing so will not modify your workspace. The
 ``catkin`` command is context-sensitive, so it will determine which workspace
 contains the current working directory.
 
+Appending or Removing List-Type Arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Several configuration options are actually *lists* of values. Normally for
+these options, the given values will replace the current values in the
+configuration.
+
+If you would only like to modify, but not replace the value of a list-type
+option, you can use the ``-a`` / ``--append-args`` and ``-r`` /
+``--remove-args`` options to append or remove elements from these lists,
+respectively.
+
+List-type options include:
+
+ - ``--cmake-args``
+ - ``--make-args``
+ - ``--catkin-make-args``
+ - ``--whitelist``
+ - ``--blacklist``
+
 Installing Packages
 ^^^^^^^^^^^^^^^^^^^
 
@@ -194,7 +214,8 @@ Full Command-Line Interface
 
 .. code-block:: text
 
-    usage: catkin config [-h] [--workspace WORKSPACE] [--profile PROFILE] [--init]
+    usage: catkin config [-h] [--workspace WORKSPACE] [--profile PROFILE]
+                         [--append-args | --remove-args] [--init]
                          [--extend EXTEND_PATH | --no-extend] [--mkdirs]
                          [--whitelist PKG [PKG ...] | --no-whitelist]
                          [--blacklist PKG [PKG ...] | --no-blacklist]
@@ -223,6 +244,12 @@ Full Command-Line Interface
                             contained within it (default: ".")
       --profile PROFILE     The name of a config profile to use (default: active
                             profile)
+
+    Behavior:
+      Options affecting argument handling.
+
+      --append-args, -a     For list-type arguments, append elements.
+      --remove-args, -r     For list-type arguments, remove elements.
 
     Workspace Context:
       Options affecting the context of the workspace.


### PR DESCRIPTION
- calling `catkin config [--append-args | -a] [ARGS]` will append elements to list args
- calling `catkin config [--remove-args | -r] [ARGS]` will remove elements from list args
- also fixing context load/save code style https://github.com/catkin/catkin_tools/pull/147#discussion_r26276789
- also fixing line-too-long code style

Fixes #176
