### PR TITLE
optimization: Improve context loading and `list` verb

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -75,8 +75,18 @@ class Context(object):
         'space_suffix']
 
     @classmethod
-    def load(cls, workspace_hint=None, profile=None, opts=None, strict=False, append=False, remove=False):
-        """Load a context from a given workspace and profile with optional modifications.
+    def load(
+        cls,
+        workspace_hint=None,
+        profile=None,
+        opts=None,
+        strict=False,
+        append=False,
+        remove=False,
+        load_env=True
+    ):
+        """Load a context from a given workspace and profile with optional
+        modifications.
 
         This function will try to load a given context from the specified
         workspace with the following resolution strategy:
@@ -101,6 +111,9 @@ class Context(object):
         :type append: bool
         :param remove: Removes any list-type opts from existing opts
         :type remove: bool
+        :param load_env: Control whether the context loads the resultspace
+        environment for the full build context
+        :type load_env: bool
 
         :returns: A potentially valid Context object constructed from the given arguments
         :rtype: Context
@@ -148,7 +161,13 @@ class Context(object):
                     context_args[k] = v
 
         # Create the build context
-        return Context(**context_args)
+        ctx = Context(**context_args)
+
+        # Don't load the cmake config if it's not needed
+        if load_env:
+            ctx.load_env()
+
+        return ctx
 
     @classmethod
     def save(cls, context):
@@ -259,6 +278,14 @@ class Context(object):
         # List of warnings about the workspace is set internally
         self.warnings = []
 
+        # Initialize environment settings set by load_env
+        self.manual_cmake_prefix_path = None
+        self.cached_cmake_prefix_path = None
+        self.env_cmake_prefix_path = None
+        self.cmake_prefix_path = None
+
+    def load_env(self):
+
         # Check for CMAKE_PREFIX_PATH in manual cmake args
         self.manual_cmake_prefix_path = ''
         for cmake_arg in self.cmake_args:
@@ -272,16 +299,14 @@ class Context(object):
         else:
             sticky_env = get_resultspace_environment(self.devel_space_abs, quiet=True)
 
+        self.cached_cmake_prefix_path = ''
         if 'CMAKE_PREFIX_PATH' in sticky_env:
             split_result_cmake_prefix_path = sticky_env.get('CMAKE_PREFIX_PATH', '').split(':')
             if len(split_result_cmake_prefix_path) > 1:
                 self.cached_cmake_prefix_path = ':'.join(split_result_cmake_prefix_path[1:])
-            else:
-                self.cached_cmake_prefix_path = ''
-        else:
-            self.cached_cmake_prefix_path = ''
 
         # Either load an explicit environment or get it from the current environment
+        self.env_cmake_prefix_path = ''
         if self.extend_path:
             extended_env = get_resultspace_environment(self.extend_path, quiet=False)
             self.env_cmake_prefix_path = extended_env.get('CMAKE_PREFIX_PATH', '')
@@ -301,8 +326,6 @@ class Context(object):
                     self.env_cmake_prefix_path = ':'.join(split_result_cmake_prefix_path[1:])
                 else:
                     self.env_cmake_prefix_path = os.environ.get('CMAKE_PREFIX_PATH', '')
-            else:
-                self.env_cmake_prefix_path = ''
 
         # Add warnings based on conflicing CMAKE_PREFIX_PATH
         if self.cached_cmake_prefix_path and self.extend_path:
@@ -474,14 +497,12 @@ class Context(object):
 
     @extend_path.setter
     def extend_path(self, value):
-        try:
-            if value is not None:
-                if not os.path.isabs(value):
-                    value = os.path.join(self.workspace, value)
-                get_resultspace_environment(value)
-            self.__extend_path = value
-        except IOError as exc:
-            raise ValueError("Unable to extend workspace from \"%s\": %s" % (value, exc.message))
+        if value is not None:
+            if not os.path.isabs(value):
+                value = os.path.join(self.workspace, value)
+            if not os.path.exists(value):
+                raise ValueError("Resultspace path '{0}' does not exist.".format(value))
+        self.__extend_path = value
 
     @property
     def source_space_abs(self):

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -85,7 +85,7 @@ def main(opts):
     needs_force = False
 
     # Load the context
-    ctx = Context.load(opts.workspace, opts.profile, opts, strict=True)
+    ctx = Context.load(opts.workspace, opts.profile, opts, strict=True, load_env=False)
 
     if not ctx:
         if not opts.workspace:

--- a/catkin_tools/verbs/catkin_list/__init__.py
+++ b/catkin_tools/verbs/catkin_list/__init__.py
@@ -18,7 +18,7 @@ from .cli import prepare_arguments
 # This describes this command to the loader
 description = dict(
     verb='list',
-    description="Lists catkin packages in a given folder.",
+    description="Lists catkin packages in the workspace or other arbitray folders.",
     main=main,
     prepare_arguments=prepare_arguments,
 )

--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -17,6 +17,12 @@ from __future__ import print_function
 import os
 import sys
 
+from catkin_tools.argument_parsing import add_context_args
+
+from catkin_tools.context import Context
+
+from catkin_tools.metadata import find_enclosing_workspace
+
 from catkin_pkg.packages import find_packages
 from catkin_pkg.package import InvalidPackage
 
@@ -27,22 +33,41 @@ clr = color_mapper.clr
 
 
 def prepare_arguments(parser):
+
+    add_context_args(parser)
+
     add = parser.add_argument
     # What packages to build
     add('folders', nargs='*',
-        help='Folders in which to find packages. (default: cwd)')
+        help='Folders in which to find packages. (default: workspace source space)')
     add('--deps', '--dependencies', default=False, action='store_true',
         help="List dependencies of each package.")
     add('--depends-on', nargs='*',
         help="List all packages that depend on supplied argument package(s).")
     add('--quiet', default=False, action='store_true',
         help="Don't print out detected package warnings.")
+    add('--unformatted', '-u', default=None, action='store_true',
+        help='Print list without punctuation and additional details.')
 
     return parser
 
 
 def main(opts):
-    folders = opts.folders or [os.getcwd()]
+
+    if opts.folders:
+        folders = opts.folders
+    else:
+        # Load the context
+        ctx = Context.load(opts.workspace, opts.profile, load_env=False)
+
+        if not ctx:
+            print(clr("@{rf}ERROR: Could not determine workspace.@|"), file=sys.stderr)
+            sys.exit(1)
+
+        folders = [ctx.source_space_abs]
+
+    list_entry_format = '@{pf}-@| @{cf}%s@|' if not opts.unformatted else '%s'
+
     opts.depends_on = set(opts.depends_on) if opts.depends_on else set()
     warnings = []
     try:
@@ -55,7 +80,7 @@ def main(opts):
                 is_run_dep = opts.depends_on.intersection(
                     run_depend_names)
                 if not opts.depends_on or is_build_dep or is_run_dep:
-                    print(clr("@{pf}-@| @{cf}%s@|" % pkg.name))
+                    print(clr(list_entry_format % pkg.name))
                     if opts.deps:
                         if build_depend_names:
                             print(clr('  @{yf}build_depend:@|'))

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -42,7 +42,8 @@ def prepare_arguments(parser):
         help='The path to the catkin workspace. Default: current working directory')
 
     add = parser_list.add_argument
-    # Nothing to do here yet
+    add('--unformatted', '-u', default=None, action='store_true',
+        help='Print profile list without punctuation and additional details.')
 
     add = parser_set.add_argument
     add('name', type=str,
@@ -75,21 +76,26 @@ def prepare_arguments(parser):
     return parser
 
 
-def list_profiles(profiles, active_profile):
+def list_profiles(profiles, active_profile, unformatted=False):
+
+    entry_format = '@{pf}-@| @{cf}%s@|' if not unformatted else '%s'
+    entry_active_format = entry_format + (' (@{yf}active@|)' if not unformatted else '')
 
     ret = []
     if len(profiles) > 0:
-        ret += [clr('[profile] Available profiles:')]
+        if not unformatted:
+            ret += [clr('[profile] Available profiles:')]
         for p in profiles:
             if p == active_profile:
-                ret += [clr('@{pf}-@| @{cf}%s@| (@{yf}active@|)' % p)]
+                ret += [clr(entry_active_format % p)]
             else:
-                ret += [clr('@{pf}-@| @{cf}%s@|' % p)]
+                ret += [clr(entry_format % p)]
     else:
-        ret += [clr(
-            '[profile] This workspace has no metadata profiles. Any '
-            'configuration settings will automatically by applied to a new '
-            'profile called `default`.')]
+        if not unformatted:
+            ret += [clr(
+                '[profile] This workspace has no metadata profiles. Any '
+                'configuration settings will automatically by applied to a new '
+                'profile called `default`.')]
 
     return '\n'.join(ret)
 
@@ -107,7 +113,7 @@ def main(opts):
         active_profile = get_active_profile(ctx.workspace)
 
         if opts.subcommand == 'list':
-            print(list_profiles(profiles, active_profile))
+            print(list_profiles(profiles, active_profile, unformatted=opts.unformatted))
 
         elif opts.subcommand == 'add':
             if opts.name in profiles:

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -70,6 +70,13 @@ Build packages with aditional CMake args:
 ... and save them to be used for the next build:
   - ``catkin build --save-config --cmake-args -DCMAKE_BUILD_TYPE=Debug``
 
+Build all packages in a given directory:
+  - ``catkin build $(catkin list -u /path/to/folder)``
+
+... or in the current folder:
+  - ``catkin build $(catkin list -u .)``
+
+
 Cleaning Build Products
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/verbs/catkin_list.rst
+++ b/docs/verbs/catkin_list.rst
@@ -1,7 +1,23 @@
 ``catkin list`` -- List Package Info
 ====================================
 
-The ``list`` verb for the ``catkin`` command is used to find and list information about catkin packages.
+The ``list`` verb for the ``catkin`` command is used to find and list
+information about catkin packages. By default, it will list the packages in the
+workspace containing the current working directoy. It can also be used to list
+the packages in any other arbitrary directory.
+
+Checking for Catkin Package Warnings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to the names of the packages in your workspace, running ``catkin
+list`` will output any warnings about catkin packages in your workspace. To
+suppress these warnings, you can use the ``--quiet`` option.
+
+Using Unformatted Output in Shell Scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``catkin list --unformatted`` is useful for automating shell scripts in UNIX
+pipe-based programs.
 
 Full Command-Line Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +27,7 @@ Full Command-Line Interface
     usage: catkin list [-h] [--deps] [--depends-on [DEPENDS_ON [DEPENDS_ON ...]]]
                        [folders [folders ...]]
 
-    Lists catkin packages in a given folder
+    Lists catkin packages in the workspace or other arbitray folders.
 
     positional arguments:
       folders               Folders in which to find packages. (default: cwd)
@@ -24,4 +40,5 @@ Full Command-Line Interface
                             List all packages that depend on supplied argument
                             package(s).
       --quiet               Don't print out detected package warnings.
+      --unformatted, -u     Print list without punctuation and additional details.
 


### PR DESCRIPTION
- Adding `--unformatted` tag to `catkin list` verb for use in cli
  completion
- Adding a lazy env-loading mode for `Context.load` when we only need
  the context for this workspace and not the loaded resultspace env
  variables like CMAKE_PREFIX_PATH. This is necessary to improve the
  runtime of `catkin list` and is also used to improve the runtime of
  `catkin clean`.
- Removing superfluous env-loading from `Context` `extend_path` accessor