### PR TITLE
build: adding experimental installwatch-based log generation

### DIFF
--- a/catkin_tools/verbs/catkin_build/job.py
+++ b/catkin_tools/verbs/catkin_build/job.py
@@ -27,6 +27,7 @@ from .common import create_build_space
 from .common import generate_env_file
 from .common import get_python_install_dir
 
+INSTALLWATCH_EXEC = which('installwatch')
 MAKE_EXEC = which('make')
 CMAKE_EXEC = which('cmake')
 
@@ -298,6 +299,7 @@ class CatkinJob(Job):
         if not os.path.isfile(makefile_path) or self.force_cmake:
             commands.append(CMakeCommand(
                 env_cmd,
+                [INSTALLWATCH_EXEC, '-o', os.path.join(self.context.build_space_abs, 'build_logs', '%s_cmake_products.log' % self.package.name)] +
                 [
                     CMAKE_EXEC,
                     pkg_dir,
@@ -309,9 +311,13 @@ class CatkinJob(Job):
         else:
             commands.append(MakeCommand(env_cmd, [MAKE_EXEC, 'cmake_check_build_system'], build_space))
         # Make command
+        make_command = (
+            [INSTALLWATCH_EXEC, '-o', os.path.join(self.context.build_space_abs, 'build_logs', '%s_make_products.log' % self.package.name)] +
+            [MAKE_EXEC] +
+            handle_make_arguments(self.context.make_args + self.context.catkin_make_args))
         commands.append(MakeCommand(
             env_cmd,
-            [MAKE_EXEC] + handle_make_arguments(self.context.make_args + self.context.catkin_make_args),
+            make_command,
             build_space
         ))
         # Make install command, if installing


### PR DESCRIPTION
This is an experiment in providing support for rolling-back the products of a package in the develspace.

This generates `PKGNAME_cmake_products.log` and `PKGNAME_make_products.log` in the `build_log` directory in the buildspace. The log is generated by running `installwatch` for the CMake and Make calls that `catkin build` makes.

These files contain all file-access operations by intercepting these specific system calls, and all file write calls are represented as `fopen` calls. This is not very portable, and I don't know if there's an easy equivalent for Windows. 

Just something to think about.

Things to do:
- [ ] add a package-specific option to `catkin clean` which cleans the results of a package and (optionally) cleans all packages which depend on that package
- [ ] add performance tests to gauge the impact of `installwatch` on building
- [ ] make it so `installwatch` is only used on `catkin` packages, for plain `cmake` packages, the `install_manifest.txt` can be used.
- [ ] add switch to turn `installwatch` on and off