### PR TITLE
Using "/bin/bash" as the default if SHELL is unset.

### DIFF
--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -53,12 +53,12 @@ def get_resultspace_environment(result_space_path, quiet=False, cached=True):
         )
 
     # Determine the shell to use to source the setup file
-    shell_path = os.environ.get('SHELL', '/bin/bash')
+    shell_path = os.environ.get('SHELL', '/bin/sh')
     (_, shell_name) = os.path.split(shell_path)
 
     # Use fallback shell if using a non-standard shell
-    if shell_name not in ['bash', 'zsh']:
-        shell_name = 'bash'
+    if shell_name not in ['bash', 'sh', 'zsh']:
+        shell_name = 'sh'
 
     # Check to make sure result_space_path contains the appropriate setup file
     setup_file_path = os.path.join(result_space_path, 'env.sh')
@@ -79,7 +79,7 @@ def get_resultspace_environment(result_space_path, quiet=False, cached=True):
         return {}
 
     # Construct a command list which sources the setup file and prints the env to stdout
-    norc_flags = {'bash': '--norc', 'zsh': '-f'}
+    norc_flags = {'bash': '--norc', 'sh': '', 'zsh': '-f'}
     subcommand = '%s %s -E environment | %s' % (setup_file_path, CMAKE_EXEC, SORT_EXEC)
 
     command = [

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -53,7 +53,7 @@ def get_resultspace_environment(result_space_path, quiet=False, cached=True):
         )
 
     # Determine the shell to use to source the setup file
-    shell_path = os.environ.get('SHELL', '')
+    shell_path = os.environ.get('SHELL', '/bin/bash')
     (_, shell_name) = os.path.split(shell_path)
 
     # Use fallback shell if using a non-standard shell


### PR DESCRIPTION
This line was recently modified so that is does not throw an exception if the SHELL environment variable is not set, but it does so by using an empty string as the default value.  This means that later code that tries to use "shell_path" to execute the shell will fail (because you can't execute an empty string).

This fixes it to use /bin/bash as the default shell if SHELL is unset, which matches the behavior a few lines later that uses "bash" as the default shell_name.