### PR TITLE
Fix KeyError crash on OSX if using different terminal

### DIFF
--- a/catkin_tools/notifications/impl.py
+++ b/catkin_tools/notifications/impl.py
@@ -29,7 +29,7 @@ def _notify_osx(title, msg):
     if open_exec is None:
         return
     command = [open_exec, app_path, '--args', title, msg]
-    terminal = os.environ['TERM_PROGRAM']
+    terminal = os.environ.get('TERM_PROGRAM')
     if terminal == "Apple_Terminal":
         command += ["-activate", "com.apple.Terminal"]
     elif terminal == "iTerm.app":


### PR DESCRIPTION
Silently fail to create notification instead of crashing. Using ``get`` will return `None` if a key is not present rather than raise a `KeyError`

Background: I'm working on OSX via a SSH shell in Linux (can't stand those key bindings :) ) and I don't have the TERM_PROGRAM env variable. All I have is TERM, which is valued as ``TERM=xterm``