### PR TITLE
Properly respect DESTDIR in the build env.

### DIFF
--- a/catkin_tools/verbs/catkin_build/job.py
+++ b/catkin_tools/verbs/catkin_build/job.py
@@ -117,7 +117,10 @@ def create_env_file(package, context):
         depends = get_cached_recursive_build_depends_in_workspace(package, context.packages)
         # For each dep add a line to source its setup file
         for dep_pth, dep in depends:
-            source_path = os.path.join(space, dep.name, 'setup.sh')
+            source_path_parts = [space, dep.name, 'setup.sh']
+            if context.destdir:
+                source_path_parts.insert(context.destdir)
+            source_path = os.path.join(*source_path_parts)
             sources.append(source_snippet.format(source_path=source_path))
     else:
         # Just source common install or devel space


### PR DESCRIPTION
This mostly fixes #235. The following now all works:

```
rosinstall_generator ros_base --rosdistro indigo --deps --tar > ros_base.rosinstall
rosinstall src ros_base.rosinstall -j8
catkin config --install --install-space /opt/foo
DESTDIR=$(pwd)/tmp catkin build
rm -rf build devel
sudo mv tmp/opt/foo/ /opt
source /opt/foo/setup.bash
roscore
```

I've also verified that `rospack find` and friends work, and binaries build and can link libraries, including in an overlaid space. Of course, because the space itself isn't relocatable, it _does not_ work in the DESTDIR location— you have to copy it to the install space for it to be functional.

So what's still broken?

```
grep -r test_ws /opt/foo
_setup_util.py:        CMAKE_PREFIX_PATH = '/opt/foo;/home/administrator/test_ws/tmp/opt/foo'.split(';')
share/*/cmake/*Config.cmake:    foreach(path /opt/foo/lib;/opt/foo/lib;/home/administrator/test_ws/tmp/opt/foo/lib)
```

Both of these could be fixed by a post-build find-and-replace, but because the space is functional without that, I'd vote to merge as is, and let that be dealt with later as required— by a flag, perhaps, or even externally by those needing DESTDIR for packaging or whatever.