### PR TITLE
[PR196-mod] Cleaning up use of build env and adding repro messages

### DIFF
--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -155,6 +155,7 @@ class ConsoleStatusController(threading.Thread):
             show_active_status=True,
             show_summary=True,
             show_full_summary=False,
+            show_repro_cmd=True,
             active_status_rate=10.0,
             pre_start_time=None):
         """
@@ -171,6 +172,7 @@ class ConsoleStatusController(threading.Thread):
         :param show_active_status: Periodically show a status line displaying the active jobs
         :param show_summary: Show numbers of jobs that completed with errors and warnings
         :param show_full_summary: Show lists of jobs in each termination category
+        :param show_repro_cmd: Show the commands to reproduce failed stages
         :param active_status_rate: The rate in Hz at which the status line should be printed
         :param pre_start_time: The actual start time to report, if preprocessing was done
         """
@@ -191,6 +193,7 @@ class ConsoleStatusController(threading.Thread):
         self.show_active_status = show_active_status
         self.show_full_summary = show_full_summary
         self.show_summary = show_summary
+        self.show_repro_cmd = show_repro_cmd
         self.active_status_rate = active_status_rate
         self.pre_start_time = pre_start_time
 
@@ -447,6 +450,10 @@ class ConsoleStatusController(threading.Thread):
                         header_border = None
                         header_title = None
                         footer_border = None
+
+                if self.show_repro_cmd and len(lines) > 0:
+                    if event.data['repro'] is not None:
+                        lines.insert(0, clr('@!@{kf}{}@|').format(event.data['repro']))
 
                 # Print the output
                 if header_border:

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -60,40 +60,25 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
         makedirs,
         path=build_space))
 
-    # Only use the env prefix for building if the develspace is isolated
-    env_prefix = []
-    if context.isolate_devel:
-        # Create an environment file
-        env_file_path = get_env_file_path(package, context)
-        stages.append(FunctionStage(
-            'envgen',
-            create_env_file,
-            package=package,
-            context=context,
-            env_file_path=env_file_path))
-
-        env_prefix = [env_file_path]
-
     # Construct CMake command
     makefile_path = os.path.join(build_space, 'Makefile')
     if not os.path.isfile(makefile_path) or force_cmake:
         stages.append(CommandStage(
             'cmake',
-            (env_prefix + [
-                CMAKE_EXEC,
-                pkg_dir,
-                '--no-warn-unused-cli',
-                '-DCATKIN_DEVEL_PREFIX=' + devel_space,
-                '-DCMAKE_INSTALL_PREFIX=' + install_space]
+            ([CMAKE_EXEC,
+              pkg_dir,
+              '--no-warn-unused-cli',
+              '-DCATKIN_DEVEL_PREFIX=' + devel_space,
+              '-DCMAKE_INSTALL_PREFIX=' + install_space]
              + context.cmake_args),
             cwd=build_space,
             logger_factory=CMakeIOBufferProtocol.factory_factory(pkg_dir),
-            occupy_job=True
-        ))
+            occupy_job=True)
+        )
     else:
         stages.append(CommandStage(
             'check',
-            env_prefix + [MAKE_EXEC, 'cmake_check_build_system'],
+            [MAKE_EXEC, 'cmake_check_build_system'],
             cwd=build_space,
             logger_factory=CMakeIOBufferProtocol.factory_factory(pkg_dir),
             occupy_job=True
@@ -105,7 +90,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
             context.make_args + context.catkin_make_args)
         stages.append(CommandStage(
             'preclean',
-            env_prefix + [MAKE_EXEC, 'clean'] + make_args,
+            [MAKE_EXEC, 'clean'] + make_args,
             cwd=build_space,
         ))
 
@@ -114,7 +99,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
         context.make_args + context.catkin_make_args)
     stages.append(CommandStage(
         'make',
-        env_prefix + [MAKE_EXEC] + make_args,
+        [MAKE_EXEC] + make_args,
         cwd=build_space,
     ))
 
@@ -122,7 +107,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
     if context.install:
         stages.append(CommandStage(
             'install',
-            env_prefix + [MAKE_EXEC, 'install'],
+            [MAKE_EXEC, 'install'],
             cwd=build_space))
 
     return Job(


### PR DESCRIPTION
This fleshes out some of the changes that were started in #249 to reduce the reliance on `build_env.sh` files in order to both speed up the build (large improvement) and increase portability.

* Adds `--env` `build` verb subcommand to get a build environment without a shell file.
* Removes old use of `build_env.sh` files
* Adds "repro" line to failed stage messages
* Relies on resultspace sourcing for isolated devel builds

See asciinema here: [![asciicast](https://asciinema.org/a/65urzf23q82rj45o1msamzsqg.png)](https://asciinema.org/a/65urzf23q82rj45o1msamzsqg)