### PR TITLE
[PR196+] jobs: Fixing environment required to run catkin test targets on pre-indigo catkin

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -37,7 +37,24 @@ from .job import get_package_build_space_path
 from .job import makedirs
 
 
+CTR_NUKE_SH = """
+#!/usr/bin/env sh
+unset CATKIN_TEST_RESULTS_DIR
+unset ROS_TEST_RESULTS_DIR
+"""
+
+
+def ctr_nuke(logger, event_queue, prefix):
+    ctr_nuke_path = os.path.join(prefix, 'etc', 'catkin', 'profile.d')
+    ctr_nuke_filename = os.path.join(ctr_nuke_path, '06-ctr-nuke.sh')
+    mkdir_p(ctr_nuke_path)
+    if not os.path.exists(ctr_nuke_filename):
+        with open(ctr_nuke_filename, 'w') as ctr_nuke_file:
+            ctr_nuke_file.write(CTR_NUKE_SH)
+    return 0
+
 # job factories
+
 
 def create_catkin_build_job(context, package, package_path, dependencies, force_cmake, pre_clean):
     """Job class for building catkin packages"""
@@ -61,9 +78,20 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
         makedirs,
         path=build_space))
 
+    # Define test results directory
+    catkin_test_results_dir = os.path.join(build_space, 'test_results')
+    ctr_env = {
+        'CATKIN_TEST_RESULTS_DIR': catkin_test_results_dir,
+        'ROS_TEST_RESULTS_DIR': catkin_test_results_dir
+    }
+
     # Construct CMake command
     makefile_path = os.path.join(build_space, 'Makefile')
     if not os.path.isfile(makefile_path) or force_cmake:
+        stages.append(FunctionStage(
+            'ctr-nuke',
+            ctr_nuke,
+            prefix=(devel_space if not context.install else install_space)))
         stages.append(CommandStage(
             'cmake',
             ([CMAKE_EXEC,
@@ -102,6 +130,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
         'make',
         [MAKE_EXEC] + make_args,
         cwd=build_space,
+        env=ctr_env if 'test' in make_args else {},
         logger_factory=CMakeMakeIOBufferProtocol.factory
     ))
 


### PR DESCRIPTION
This resolves issues described in #139 (i.e. running `catkin test` on Hydro). It does this by doing two things:

1. Overriding the `05.catkin-test-results.sh` file with the `06-ctr-nuke.sh` file after the Catkin CMake configure stage
2. Properly setting the `CATKIN_TEST_RESULTS_DIR` and `ROS_TEST_RESULTS_DIR` environment variables when running Catkin build `make` stage when `test` is in `make_args` 

What's nice is that this only requires changes in the catkin build job definition.