### PR TITLE
getting all args in bash is '$@'

### DIFF
--- a/catkin_tools/verbs/catkin_shell_verbs.bash
+++ b/catkin_tools/verbs/catkin_shell_verbs.bash
@@ -54,7 +54,11 @@ function catkin() {
   fi
 
   # Capture original args
-  ORIG_ARGS=(${@[*]})
+  if [[ "$SHELL_EXT" == "bash" ]]; then
+      ORIG_ARGS=$@
+  else
+      ORIG_ARGS=(${@[*]})
+  fi
 
   # Handle main arguments
   OPTSPEC=":hw-:"


### PR DESCRIPTION
without this fix, we'll get  following error on catkin 0.3.1
```
# source `catkin --locate-extra-shell-verbs`
$ catkin cd
bash: ${@[*]}: bad substitution
```

maybe original developer  using zsh,  I have checked patched version works both zsh and bash