### PR TITLE
[PR196 1/3+] Generate .catkin develspace manifest file

### DIFF
--- a/catkin_tools/execution/stages.py
+++ b/catkin_tools/execution/stages.py
@@ -15,6 +15,11 @@
 import os
 
 try:
+    basestring
+except NameError:
+    basestring = str
+
+try:
     from shlex import quote as cmd_quote
 except ImportError:
     from pipes import quote as cmd_quote
@@ -76,7 +81,7 @@ class CommandStage(Stage):
         :param logger_factory: The factory to use to construct a logger (default: IOBufferProtocol.factory)
         """
 
-        if not type(cmd) in [list, tuple] or not all([type(s) is str for s in cmd]):
+        if not type(cmd) in [list, tuple] or not all([isinstance(s, basestring) for s in cmd]):
             raise ValueError('Command stage must be a list of strings: {}'.format(cmd))
         super(CommandStage, self).__init__(label, logger_factory, occupy_job)
 


### PR DESCRIPTION
Taking over responsibility for populating and updating the `.catkin` devel manifest file. See: https://github.com/catkin/catkin_tools/pull/249#issuecomment-170764943

This also makes catkin "parallel-safe" mode unnecessary, i.e. https://github.com/ros/catkin/issues/675

@cmansley