### PR TITLE
Add `.built_by` file to list of non-build files in the buildspace 

### DIFF
--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -32,7 +32,7 @@ clr = color_mapper.clr
 
 # Exempt build directories
 # See https://github.com/catkin/catkin_tools/issues/82
-exempt_build_files = ['build_logs', '.catkin_tools.yaml']
+exempt_build_files = ['build_logs', '.built_by', '.catkin_tools.yaml']
 
 setup_files = ['.catkin', 'env.sh', 'setup.bash', 'setup.sh', 'setup.zsh', '_setup_util.py']
 


### PR DESCRIPTION
https://github.com/ros-infrastructure/catkin_pkg/pull/122 brokes `catkin clean -o` as follows
```
$ catkin clean -o
[clean] Removing orphaned build directories from /home/k-okada/catkin_ws/build
 - Removing /home/k-okada/catkin_ws/build/.built_by
Traceback (most recent call last):
  File "/usr/bin/catkin", line 9, in <module>
    load_entry_point('catkin-tools==0.3.1', 'console_scripts', 'catkin')()
  File "/usr/lib/python2.7/dist-packages/catkin_tools/commands/catkin.py", line 229, in main
    sys.exit(args.main(args) or 0)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_clean/cli.py", line 133, in main
    shutil.rmtree(pkg_build_path)
  File "/usr/lib/python2.7/shutil.py", line 239, in rmtree
    onerror(os.listdir, path, sys.exc_info())
  File "/usr/lib/python2.7/shutil.py", line 237, in rmtree
    names = os.listdir(path)
OSError: [Errno 20] Not a directory: '/home/k-okada/catkin_ws/build/.built_by'
```