### PR TITLE
Add trollius dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ catkin_pkg
 setuptools
 sphinxcontrib-ansi
 sphinxcontrib-programoutput
+trollius


### PR DESCRIPTION
I think this got added in the source recently and is missing from the requirements.txt file