### PR TITLE
Fixes the bash completion path for empty prefix.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def _resolve_prefix(prefix, type):
         if sys.prefix.startswith(osx_system_prefix):
             return '/usr/share'
     elif type == 'bash_comp':
-        if prefix == '/usr':
+        if (prefix == '/usr') or (prefix == ''):
             return '/'
         if sys.prefix.startswith(osx_system_prefix):
             return '/'


### PR DESCRIPTION
I noticed this issue yesterday when I installed catkin tools; there was no bash completion out of the box. I did some digging and came to the conclusion that the completion files are installed in the wrong folder. Tested on a fresh trusty64 virtual machine with `sudo python setup.py install -v`:

In the latest version the relevant line from the installation log is:
> copying completion/catkin_tools-completion.bash -> /usr/local/etc/bash_completion.d

Before 9bec9e7bd7dc9d26a4372e14e3911bb175ee04d3, this line was: 
> copying completion/catkin_tools-completion.bash -> /etc/bash_completion.d

For the default empty prefix, I believe it should be the same output as `/usr`'s, such that the installation path of the bash completion file is `/etc/bash_completion.d`.
