### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.