### PR TITLE
installation: Prevent setup.py's first argparse from displaying unhelpful help

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class PermissiveInstall(install):
                 os.chmod(file, mode)
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('--prefix', default='',
                     help='prefix to install data files')
 opts, _ = parser.parse_known_args(sys.argv)


### PR DESCRIPTION
The first argparse that is used to read the prefix argument also added a help, which resulted in this argparse wrongfully responding to the `--help` argument. The result was that `python setup.py --help` did not list all options available, preventing the first `ArgumentParser` from adding the help alleviates this problem.

This parser is only there to detect the `--prefix` argument and based on the `data_files` are added. Another solution would be to do away with this additional parser and add the `data_files` after the arguments are parsed, so in the constructor of the `PermissiveInstall` class:
```python
    def __init__(self, dist, *args, **kwargs):
        install.__init__(self, dist, *args, **kwargs)
        dist.data_files = get_data_files(self.prefix if self.prefix else "")
```
However, I'm not entirely sure about the implications of this, since this only adds the `data_files` when the `install` command is issued and not with any of the other commands.

Solving this issue by preventing the first parser from hijacking the help seems to be the safer option.