### PR TITLE
fallback to sys.prefix if opts.prefix is not set in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,15 +89,16 @@ To enable tab completion, add the following to your '~/.bashrc':
   source {0}
 
 ----------------------------------------------------------------
-""".format(os.path.join(self.install_data,
-           'etc/bash_completion.d',
-           'catkin_tools-completion.bash')))
+""".format(os.path.join(
+                self.install_data,
+                'etc/bash_completion.d',
+                'catkin_tools-completion.bash')))
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--prefix', default='',
+parser.add_argument('--prefix', default=None,
                     help='prefix to install data files')
 opts, _ = parser.parse_known_args(sys.argv)
-prefix = opts.prefix
+prefix = opts.prefix or sys.prefix
 
 setup(
     name='catkin_tools',


### PR DESCRIPTION
Follow up to https://github.com/catkin/catkin_tools/issues/294.

@cottsay maybe you could give this a try to see if allows you to operate without using `--prefix` at all?

@wkentaro I think this particular behavior got lost in this commit: https://github.com/catkin/catkin_tools/commit/9bec9e7bd7dc9d26a4372e14e3911bb175ee04d3#diff-2eeaed663bd0d25b7e608891384b7298L42 Do you have any comments or objections to this new pull request?