### PR TITLE
normalize extend_path

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -493,6 +493,8 @@ class Context(object):
         if value is not None:
             if not os.path.isabs(value):
                 value = os.path.join(self.workspace, value)
+            # remove double or trailing slashes
+            value = os.path.normpath(value)
             if not os.path.exists(value):
                 raise ValueError("Resultspace path '{0}' does not exist.".format(value))
         self.__extend_path = value


### PR DESCRIPTION
... to get rid of trailing or double slashes which cause the consistency check to fail without real reason:

An extend_path `/opt/ros/indigo/` will not be found in catkin's `CMAKE_PREFIX_PATH` which will list the path without the trailing slash.