### PR TITLE
catkin_build: fix cmake args check

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -364,7 +364,7 @@ def main(opts):
     # Get the last build context
     build_metadata = get_metadata(ctx.workspace, ctx.profile, 'build')
 
-    if build_metadata.get('cmake_args') != ctx.cmake_args or build_metadata.get('cmake_args') != opts.cmake_args:
+    if build_metadata.get('cmake_args') != ctx.cmake_args:
         opts.force_cmake = True
 
     if build_metadata.get('needs_force', False):


### PR DESCRIPTION
The check as it was would force a cmake run on every package if
cmake_args were saved in the context, since then
ctx.cmake_args != opts.cmake_args.

Since opts.cmake_args are already appended to ctx.cmake_args by
Context.load, the second check is unnecessary.