### PR TITLE
remove apparently unused variables

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -243,7 +243,6 @@ def link_devel_products(
 
         # create directories in the destination develspace
         for dirname in dirs:
-            source_dir = os.path.join(source_path, dirname)
             dest_dir = os.path.join(dest_path, dirname)
 
             if not os.path.exists(dest_dir):

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -215,10 +215,6 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
 
     # Package build space path
     build_space = context.package_build_space(package)
-    # Package devel space path
-    devel_space = context.package_devel_space(package)
-    # Package install space path
-    install_space = context.package_install_space(package)
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
 


### PR DESCRIPTION
In two places there seems to be unused variables. In my experience this either means someone intended to use them but ended up not using them for some reason or they intended to use them and accidentally used something else. @jbohren can you have a look at these and see which is the case. I think we can just merge this as-is.