### PR TITLE
put warned "jid's" in the warneds dict

### DIFF
--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -310,7 +310,7 @@ class ConsoleStatusController(threading.Thread):
                 if jid in failed_jobs:
                     faileds[jid] = templates['failed']
                 elif jid in warned_jobs:
-                    successfuls[jid] = templates['warned']
+                    warneds[jid] = templates['warned']
                 else:
                     successfuls[jid] = templates['successful']
             else:


### PR DESCRIPTION
@jbohren I think this is the right fix, but I detected it by noticing that the `warneds` variable was unused. This is a great example of why having a tool in your editor to warn you about unused variables is a good thing.

I believe this might be contributing to a bug I noticed, but hadn't yet reported where the notification would say "built successfully without warnings" when in fact there were warnings. Let me know what you think.