### PR TITLE
metadata: always initialize metadata, avoid overwriting migration

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -51,7 +51,7 @@ def get_prebuild_package(build_space_abs, devel_space_abs, force):
     """
 
     # Get the path to the prebuild package
-    prebuild_path = os.path.join(devel_space_abs, '.private', 'catkin_tools_prebuild')
+    prebuild_path = os.path.join(build_space_abs, 'catkin_tools_prebuild')
     if not os.path.exists(prebuild_path):
         mkdir_p(prebuild_path)
 

--- a/docs/examples/quickstart_ws/2_postbuild.out
+++ b/docs/examples/quickstart_ws/2_postbuild.out
@@ -15,11 +15,9 @@
 ├── devel
 │   ├── .built_by
 │   ├── .catkin
-│   ├── CMakeLists.txt -> /tmp/quickstart_ws/devel/.private/catkin_tools_prebuild/CMakeLists.txt
 │   ├── env.sh -> /tmp/quickstart_ws/devel/.private/catkin_tools_prebuild/env.sh
 │   ├── etc
 │   ├── lib
-│   ├── package.xml -> /tmp/quickstart_ws/devel/.private/catkin_tools_prebuild/package.xml
 │   ├── .private
 │   ├── setup.bash -> /tmp/quickstart_ws/devel/.private/catkin_tools_prebuild/setup.bash
 │   ├── setup.sh -> /tmp/quickstart_ws/devel/.private/catkin_tools_prebuild/setup.sh


### PR DESCRIPTION
This fixes an issue where a user can lose workspace configuration when migrating from 0.3.1 to 0.4.0.

Also fixes:
- #319 