### PR TITLE
setup: Installation with `--user` fails with data files

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -61,6 +61,10 @@ Then install with the ``setup.py`` file:
 
     Depending on your environment/machine, you may need to use ``sudo`` with this command.
 
+.. note::
+
+    If you want to perform a *local* install to your home directory, use the ``install --user`` option.
+
 Developing
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ To enable tab completion, add the following to your '~/.bashrc':
 
 parser = argparse.ArgumentParser(add_help=False)
 prefix_group = parser.add_mutually_exclusive_group()
-prefix_group.add_argument('--user','--home', action='store_true')
+prefix_group.add_argument('--user', '--home', action='store_true')
 prefix_group.add_argument('--prefix', default=None)
 
 opts, _ = parser.parse_known_args(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import argparse
 from distutils import log
 import os
+import site
 from stat import ST_MODE
 import sys
 
@@ -95,10 +96,14 @@ To enable tab completion, add the following to your '~/.bashrc':
                         'catkin_tools-completion.bash')))
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--prefix', default=None,
+prefix_group = parser.add_mutually_exclusive_group()
+prefix_group.add_argument('--user','--home', action='store_true',
+                    help='install files to $HOME/.local')
+prefix_group.add_argument('--prefix', default=None,
                     help='prefix to install data files')
 opts, _ = parser.parse_known_args(sys.argv)
-prefix = opts.prefix or sys.prefix
+userbase = site.getuserbase() if opts.user else None
+prefix = userbase or opts.prefix or sys.prefix
 
 setup(
     name='catkin_tools',

--- a/setup.py
+++ b/setup.py
@@ -95,12 +95,11 @@ To enable tab completion, add the following to your '~/.bashrc':
                         'etc/bash_completion.d',
                         'catkin_tools-completion.bash')))
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(add_help=False)
 prefix_group = parser.add_mutually_exclusive_group()
-prefix_group.add_argument('--user','--home', action='store_true',
-                    help='install files to $HOME/.local')
-prefix_group.add_argument('--prefix', default=None,
-                    help='prefix to install data files')
+prefix_group.add_argument('--user','--home', action='store_true')
+prefix_group.add_argument('--prefix', default=None)
+
 opts, _ = parser.parse_known_args(sys.argv)
 userbase = site.getuserbase() if opts.user else None
 prefix = userbase or opts.prefix or sys.prefix


### PR DESCRIPTION
This PR enables users to use the standard `--user` and `--home` options to install to `~/.local`. Otherwise, the following happens:

```
$ python setup.py install --user
running install
running build
running build_py
running install_lib
running install_data
copying completion/catkin_tools-completion.bash -> /etc/bash_completion.d
error: /etc/bash_completion.d/catkin_tools-completion.bash: Permission denied
```

This also suppresses misinformative help as described in #291.