### PR TITLE
docs: fix link to milestones

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ For documentation on creating catkin packages, see: http://docs.ros.org/api/catk
 
 .. note::
 
-  This package was announced in March 2015 and is still in beta. A second beta release is planned for `April 2016 <https://github.com/catkin/catkin_tools/milestones>`.
+  This package was announced in March 2015 and is still in beta. A second beta release is planned for `April 2016`. https://github.com/catkin/catkin_tools/milestones
 
 .. note::
 


### PR DESCRIPTION
It currently doesn't render the link as clickable (see top of docs):

http://catkin-tools.readthedocs.org/en/latest/index.html