### PR TITLE
Unit tests for `catkin profile` and metadata fixes

### DIFF
--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -186,7 +186,10 @@ def catkin_main(sysargs):
             pkg_resources.get_distribution('catkin_tools').version,
             date.today().year)
         )
-        print('Released under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)')
+        print('catkin_tools is released under the Apache License,'
+              ' Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)')
+        print('---')
+        print('Using Python {}'.format(''.join(sys.version.split('\n'))))
         sys.exit(0)
 
     # Check for --test-colors

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -289,7 +289,7 @@ def get_profile_names(workspace_path):
     profiles_path = get_profiles_path(workspace_path)
 
     if os.path.exists(profiles_path):
-        directories = os.walk(profiles_path).next()[1]
+        directories = next(os.walk(profiles_path))[1]
 
         return directories
 

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -79,9 +79,10 @@ def determine_packages_to_be_built(packages, context, workspace_packages):
 
     # If there are no packages raise
     if not workspace_packages:
-        sys.exit("[build] No packages were found in the source space '{0}'".format(context.source_space_abs))
-    wide_log("[build] Found '{0}' packages in {1}."
-             .format(len(workspace_packages), format_time_delta(time.time() - start)))
+        log("[build] No packages were found in the source space '{0}'".format(context.source_space_abs))
+    else:
+        wide_log("[build] Found '{0}' packages in {1}."
+                 .format(len(workspace_packages), format_time_delta(time.time() - start)))
 
     # Order the packages by topology
     ordered_packages = topological_order_packages(workspace_packages)
@@ -319,7 +320,6 @@ def build_isolated_workspace(
     # Check the number of packages to be built
     if len(packages_to_be_built) == 0:
         log(clr('[build] No packages to be built.'))
-        return
 
     # Assert start_with package is in the workspace
     verify_start_with_option(
@@ -382,8 +382,6 @@ def build_isolated_workspace(
     # Handle the prebuild jobs if the develspace is linked
     prebuild_pkg_deps = []
     if context.link_devel:
-        wide_log('[build] Preparing linked develspace...')
-
         prebuild_pkg = None
 
         # Construct a dictionary to lookup catkin package by name

--- a/tests/system/verbs/catkin_build/test_build.py
+++ b/tests/system/verbs/catkin_build/test_build.py
@@ -65,7 +65,7 @@ def test_build_auto_init_no_pkgs():
     with redirected_stdio() as (out, err):
         with workspace_factory() as wf:
             wf.build()
-            assert catkin_failure(BUILD)
+            assert catkin_success(BUILD)
             assert_workspace_initialized('.')
     assert_no_warnings(out)
 

--- a/tests/system/verbs/catkin_profile/test_profile.py
+++ b/tests/system/verbs/catkin_profile/test_profile.py
@@ -1,0 +1,23 @@
+import os
+
+from ....utils import in_temporary_directory
+from ....utils import assert_cmd_success
+
+from ....workspace_assertions import assert_workspace_initialized
+from ....workspace_assertions import assert_warning_message
+from ....workspace_assertions import assert_no_warnings
+
+
+@in_temporary_directory
+def test_profile_list():
+    assert_cmd_success(['mkdir', 'src'])
+    assert_cmd_success(['catkin', 'init'])
+    assert_cmd_success(['catkin', 'build'])
+    assert_cmd_success(['catkin', 'profile', 'list'])
+
+@in_temporary_directory
+def test_profile_set():
+    assert_cmd_success(['mkdir', 'src'])
+    assert_cmd_success(['catkin', 'init'])
+    assert_cmd_success(['catkin', 'build'])
+    assert_cmd_success(['catkin', 'profile', 'set', 'default'])


### PR DESCRIPTION
This PR adds unit tests for `catkin profile`, which is failing on Python 3. It also adds more output to `catkin --version`, and makes it so that an empty workspace can still be built.

Fixes #327.