### PR TITLE
Fix cleaning specific packages

### DIFF
--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -194,7 +194,7 @@ def clean_profile(opts, profile):
     if clean_all:
         opts.logs = opts.build = opts.devel = opts.install = True
 
-    # Make sure the user intends to clena everything
+    # Make sure the user intends to clean everything
     spaces_to_clean_msgs = []
 
     if not (opts.yes or opts.dry_run):

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -206,6 +206,8 @@ def clean_profile(opts, profile):
             spaces_to_clean_msgs.append(clr("[clean] Devel Space:   @{yf}{}").format(ctx.devel_space_abs))
         if opts.install and install_exists:
             spaces_to_clean_msgs.append(clr("[clean] Install Space: @{yf}{}").format(install_path))
+        if opts.packages:
+            spaces_to_clean_msgs.append(clr("[clean] Packages: @{yf}{}").format(', '.join(opts.packages)))
 
         if len(spaces_to_clean_msgs) == 0 and not opts.deinit:
             log("[clean] Nothing to be cleaned for profile:  `{}`".format(profile))


### PR DESCRIPTION
**before**
```
% catkin clean apc2015_common
[clean] Nothing to be cleaned for profile:  `default`
```

**after**
```
% catkin clean apc2015_common

[clean] Warning: This will completely remove the following directories. (Use `--yes` to skip this check)
[clean] Packages: apc2015_common

[clean] Are you sure you want to completely remove the directories listed above? [yN]: y
Starting  >>> apc2015_common             
Finished  <<< apc2015_common              [ 0.0 seconds ]
[clean] Summary: All 1 packages succeeded!
[clean]   Ignored:   None.
[clean]   Warnings:  None.
[clean]   Abandoned: None.
[clean]   Failed:    None.
[clean] Runtime: 0.4 seconds total.
[clean] Note: Parts of the workspace have been cleaned which will necessitate re-configuring CMake on the next build.
```