### PR TITLE
Add test for unicode in env

### DIFF
--- a/tests/system/verbs/catkin_build/test_unicode_in_env.py
+++ b/tests/system/verbs/catkin_build/test_unicode_in_env.py
@@ -1,0 +1,20 @@
+import os
+
+from ....utils import catkin_success
+
+from ...workspace_factory import workspace_factory
+
+
+def test_catkin_build_with_unicode_in_env():
+    with workspace_factory() as wf:
+        wf.create_package('foo', depends=['bar'])
+        wf.create_package('bar')
+        wf.build()
+
+        print('Workspace: {0}'.format(wf.workspace))
+
+        assert os.path.isdir(wf.workspace)
+
+        env = {'NON_ASCII': '\xc3\xb6'}
+        cmd = ['build', '--no-status', '--no-notify', '--verbose']
+        assert catkin_success(cmd, env)


### PR DESCRIPTION
Regression test for issue #338. I committed it [before the fix](https://github.com/scpeters/catkin_tools/commits/confirm_unicode_failure) to [confirm the failure](https://travis-ci.org/scpeters/catkin_tools/builds/124279451).