### PR TITLE
resultspace: Fixing environment cache checking

### DIFF
--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -38,8 +38,7 @@ DEFAULT_SHELL = '/bin/bash'
 _resultspace_env_cache = {}
 _resultspace_env_hooks_cache = {}
 
-
-def get_resultspace_environment(result_space_path, base_env={}, quiet=False, cached=True, strict=True):
+def get_resultspace_environment(result_space_path, base_env=None, quiet=False, cached=True, strict=True):
     """Get the environemt variables which result from sourcing another catkin
     workspace's setup files as the string output of `cmake -E environment`.
     This cmake command is used to be as portable as possible.
@@ -55,6 +54,10 @@ def get_resultspace_environment(result_space_path, base_env={}, quiet=False, cac
 
     :returns: a dictionary of environment variables and their values
     """
+
+    # Set bae environment to the current environment
+    if base_env is None:
+        base_env = dict(os.environ)
 
     # Get the MD5 checksums for the current env hooks
     # TODO: the env hooks path should be defined somewhere
@@ -173,7 +176,7 @@ def get_resultspace_environment(result_space_path, base_env={}, quiet=False, cac
     return dict(env_dict)
 
 
-def load_resultspace_environment(result_space_path, cached=True):
+def load_resultspace_environment(result_space_path, base_env=None, cached=True):
     """Load the environemt variables which result from sourcing another
     workspace path into this process's environment.
 
@@ -182,7 +185,7 @@ def load_resultspace_environment(result_space_path, cached=True):
     :param cached: use the cached environment
     :type cached: bool
     """
-    env_dict = get_resultspace_environment(result_space_path, cached=cached)
+    env_dict = get_resultspace_environment(result_space_path, base_env=base_env, cached=cached)
     try:
         os.environ.update(env_dict)
     except TypeError:

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -67,9 +67,8 @@ def get_resultspace_environment(result_space_path, base_env={}, quiet=False, cac
         env_hooks = []
 
     # Check the cache first, if desired
-    if cached:
-        cached_env_hooks = _resultspace_env_hooks_cache.get(result_space_path, [])
-        if result_space_path in _resultspace_env_cache and env_hooks == cached_env_hooks:
+    if cached and result_space_path in _resultspace_env_hooks_cache and result_space_path in _resultspace_env_cache:
+        if env_hooks == _resultspace_env_hooks_cache.get(result_space_path):
             return dict(_resultspace_env_cache[result_space_path])
 
     # Check to make sure result_space_path is a valid directory


### PR DESCRIPTION
Currently, it could blow away environment if there are no env hooks in the resultspace (fixes #350)

@mikepurvis Give this branch a shot.