### PR TITLE
io: Better tracebacks, fixing unicode error

### DIFF
--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -150,7 +150,6 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                         logger.err('  {}'.format(arg_val))
                     for arg_name, arg_val in stage.kwargs.items():
                         logger.err('  {}: {}'.format(arg_name, arg_val))
-                    logger.err(str(traceback.format_exc()))
                     retcode = 3
             else:
                 raise TypeError("Bad Job Stage: {}".format(stage))

--- a/catkin_tools/execution/io.py
+++ b/catkin_tools/execution/io.py
@@ -25,6 +25,19 @@ from .events import ExecutionEvent
 
 MAX_LOGFILE_HISTORY = 10
 
+if type(u'') == str:
+    def _encode(string):
+        """Encode a Python 3 str into bytes.
+        :type data: str
+        """
+        return string.encode('utf-8')
+else:
+    def _encode(string):
+        """Encode a Python 2 str into bytes.
+        :type data: str
+        """
+        return string.decode('utf-8').encode('utf-8')
+
 
 class IOBufferContainer(object):
 
@@ -109,7 +122,7 @@ class IOBufferContainer(object):
         """Encode a Python str into bytes.
         :type data: str
         """
-        return data.encode('utf-8')
+        return _encode(data)
 
     def _decode(self, data):
         """Decode bytes into Python str.

--- a/catkin_tools/execution/stages.py
+++ b/catkin_tools/execution/stages.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import traceback
 
 from catkin_tools.common import string_type
 
@@ -169,5 +170,9 @@ class FunctionStage(Stage):
         self.kwargs = kwargs
 
         def function_proxy(logger, event_queue):
-            return function(logger, event_queue, *args, **kwargs)
+            try:
+                return function(logger, event_queue, *args, **kwargs)
+            except:
+                logger.err(str(traceback.format_exc()))
+                raise
         self.function = function_proxy

--- a/tests/system/resources/catkin_pkgs/products_unicode/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/products_unicode/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(products_unicode)
+find_package(catkin REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}_lib
+  CFG_EXTRAS extras.cmake)
+
+include_directories(include)
+
+add_library(${PROJECT_NAME}_lib lib.cpp)
+set_target_properties(${PROJECT_NAME}_lib PROPERTIES OUTPUT_NAME "${PROJECT_NAME}_lïb")
+target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES})
+
+add_executable(main main.cpp)
+set_target_properties(main PROPERTIES OUTPUT_NAME "maïn")
+target_link_libraries(main ${PROJECT_NAME}_lib ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}_lib main
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )

--- a/tests/system/resources/catkin_pkgs/products_unicode/cmake/extras.cmake.develspace.in
+++ b/tests/system/resources/catkin_pkgs/products_unicode/cmake/extras.cmake.develspace.in
@@ -1,0 +1,1 @@
+set($ENV{PRODUCTS_UNICODE} "devel")

--- a/tests/system/resources/catkin_pkgs/products_unicode/cmake/extras.cmake.installspace.in
+++ b/tests/system/resources/catkin_pkgs/products_unicode/cmake/extras.cmake.installspace.in
@@ -1,0 +1,1 @@
+set($ENV{PRODUCTS_UNICODE} "install")

--- a/tests/system/resources/catkin_pkgs/products_unicode/include/make_products_0/fun.h
+++ b/tests/system/resources/catkin_pkgs/products_unicode/include/make_products_0/fun.h
@@ -1,0 +1,3 @@
+namespace make_products_0 {
+  int fun();
+}

--- a/tests/system/resources/catkin_pkgs/products_unicode/lib.cpp
+++ b/tests/system/resources/catkin_pkgs/products_unicode/lib.cpp
@@ -1,0 +1,4 @@
+#include <make_products_0/fun.h>
+int make_products_0::fun() {
+  return 0;
+}

--- a/tests/system/resources/catkin_pkgs/products_unicode/main.cpp
+++ b/tests/system/resources/catkin_pkgs/products_unicode/main.cpp
@@ -1,0 +1,6 @@
+
+#include <make_products_0/fun.h>
+
+int main(int argc, char** argv) {
+  return make_products_0::fun();
+}

--- a/tests/system/resources/catkin_pkgs/products_unicode/package.xml
+++ b/tests/system/resources/catkin_pkgs/products_unicode/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package>
+  <name>products_unicode</name>
+  <version>0.1.0</version>
+  <description>This package generates products in the make stage.</description>
+  <maintainer email="todo@todo.todo">todo</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/tests/system/verbs/catkin_build/test_build.py
+++ b/tests/system/verbs/catkin_build/test_build.py
@@ -301,3 +301,17 @@ def test_install_catkin_destdir():
                         setup_dir_correct = True
                         break
             assert setup_dir_correct is True
+
+
+def test_pkg_with_unicode_names():
+    """Test building a package with unicode file names."""
+    with redirected_stdio() as (out, err):
+        with workspace_factory() as wf:
+            print(os.getcwd)
+            wf.build()
+            shutil.copytree(
+                os.path.join(RESOURCES_DIR, 'catkin_pkgs', 'products_unicode'),
+                os.path.join('src/cmake_pkgs'))
+
+            assert catkin_success(['config', '--link-devel'])
+            assert catkin_success(BUILD)

--- a/tests/system/verbs/catkin_profile/test_profile.py
+++ b/tests/system/verbs/catkin_profile/test_profile.py
@@ -15,6 +15,7 @@ def test_profile_list():
     assert_cmd_success(['catkin', 'build'])
     assert_cmd_success(['catkin', 'profile', 'list'])
 
+
 @in_temporary_directory
 def test_profile_set():
     assert_cmd_success(['mkdir', 'src'])


### PR DESCRIPTION
This reproduces the problem seen in #311 and improves traceback reporting from `FunctionStage` job stages. It also adds a fix for #311, though it's a quick fix and feels sub-optimal. There should be a better way of handling this for Python2 and Python3 without incurring so much additional overhead.
