### PR TITLE
fix bash completion

### DIFF
--- a/completion/catkin_tools-completion.bash
+++ b/completion/catkin_tools-completion.bash
@@ -135,11 +135,6 @@ _catkin()
       ;;
   esac
 
-  IFS="$OLDIFS"
-  if [[ ${#COMPREPLY[*]} -eq 1 ]]; then #Only one completion
-    COMPREPLY=( ${COMPREPLY[0]%% - *} ) #Remove ' - ' and everything after
-  fi
-
   return 0
 }
 


### PR DESCRIPTION
Merge of #365 broke bash completion. Compared to my original PR #209, #365 leaves some old, but obsolete code. This PR removes it at thus fixes bash completion.