### PR TITLE
Add new initial command stage to mutex all reads of the installspace.

### DIFF
--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -59,9 +59,6 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
     # Jobs start occuping a jobserver job
     occupying_job = True
 
-    # Load environment for this job
-    job_env = job.getenv(os.environ)
-
     # Execute each stage of this job
     for stage in job.stages:
         # Logger reference in this scope for error reporting
@@ -102,7 +99,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                     while True:
                         try:
                             # Update the environment for this stage (respects overrides)
-                            stage.update_env(job_env)
+                            stage.update_env(job.env)
 
                             # Get the logger
                             protocol_type = stage.logger_factory(verb, job.jid, stage.label, event_queue, log_path)

--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -14,7 +14,6 @@
 
 from __future__ import print_function
 
-import os
 import traceback
 
 from itertools import tee

--- a/catkin_tools/execution/jobs.py
+++ b/catkin_tools/execution/jobs.py
@@ -24,7 +24,7 @@ class Job(object):
 
     """A Job is a series of operations, each of which is considered a "stage" of the job."""
 
-    def __init__(self, jid, deps, env_loader, stages, continue_on_failure=True):
+    def __init__(self, jid, deps, env, stages, continue_on_failure=True):
         """
         jid: Unique job identifier
         deps: Dependencies (in terms of other jid's)
@@ -33,7 +33,7 @@ class Job(object):
         """
         self.jid = jid
         self.deps = deps
-        self.env_loader = env_loader
+        self.env = env
         self.stages = stages
         self.continue_on_failure = continue_on_failure
 
@@ -48,6 +48,3 @@ class Job(object):
     def any_deps_failed(self, completed_jobs):
         """Return True if any dependencies which have been completed have failed."""
         return any([not completed_jobs.get(dep_id, True) for dep_id in self.deps])
-
-    def getenv(self, env):
-        return self.env_loader(env)

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -351,7 +351,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
     # Environment dictionary for the job, which will be built
-    # up by the executions in the getenv stage.
+    # up by the executions in the loadenv stage.
     job_env = dict(os.environ)
 
     # Create job stages
@@ -506,26 +506,14 @@ def create_catkin_clean_job(
         clean_install):
     """Generate a Job that cleans a catkin package"""
 
+    stages = []
+
     # Package build space path
     build_space = context.package_build_space(package)
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
-    # Environment dictionary for the job, which will be built
-    # up by the executions in the getenv stage.
-    job_env = dict(os.environ)
-
-    # Create job stages
-    stages = []
-
-    # Get environment for job.
-    stages.append(FunctionStage(
-        'getenv',
-        load_env,
-        locked_resource='installspace',
-        job_env=job_env,
-        package=package,
-        context=context
-    ))
+    # Environment dictionary for the job, empty for a clean job
+    job_env = {}
 
     # Remove installed files
     if clean_install:

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -35,7 +35,7 @@ from .commands.cmake import get_installed_files
 from .commands.make import MAKE_EXEC
 
 from .utils import copyfiles
-from .utils import load_env
+from .utils import loadenv
 from .utils import makedirs
 from .utils import rmfiles
 
@@ -357,10 +357,10 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
     # Create job stages
     stages = []
 
-    # Get environment for job.
+    # Load environment for job.
     stages.append(FunctionStage(
-        'getenv',
-        load_env,
+        'loadenv',
+        loadenv,
         locked_resource='installspace',
         job_env=job_env,
         package=package,

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -31,7 +31,7 @@ from .commands.cmake import get_installed_files
 from .commands.make import MAKE_EXEC
 
 from .utils import copyfiles
-from .utils import get_env_loader
+from .utils import load_env
 from .utils import makedirs
 from .utils import rmfiles
 
@@ -217,6 +217,9 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
     build_space = context.package_build_space(package)
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
+    # Environment dictionary for the job, which will be built
+    # up by the executions in the getenv stage.
+    job_env = dict(os.environ)
 
     # Get actual staging path
     dest_path = context.package_dest_path(package)
@@ -224,6 +227,16 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
 
     # Create job stages
     stages = []
+
+    # Get environment for job.
+    stages.append(FunctionStage(
+        'getenv',
+        load_env,
+        locked_resource='installspace',
+        job_env=job_env,
+        package=package,
+        context=context
+    ))
 
     # Create package build space
     stages.append(FunctionStage(
@@ -321,7 +334,7 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
     return Job(
         jid=package.name,
         deps=dependencies,
-        env_loader=get_env_loader(package, context),
+        env=job_env,
         stages=stages)
 
 
@@ -340,9 +353,24 @@ def create_cmake_clean_job(
     build_space = context.package_build_space(package)
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
+    # Environment dictionary for the job, which will be built
+    # up by the executions in the getenv stage.
+    job_env = dict(os.environ)
 
+    # Create job stages
     stages = []
 
+    # Get environment for job.
+    stages.append(FunctionStage(
+        'getenv',
+        load_env,
+        locked_resource='installspace',
+        job_env=job_env,
+        package=package,
+        context=context
+    ))
+
+    # Remove installed files
     if clean_install and context.install:
         installed_files = get_installed_files(context.package_metadata_path(package))
         stages.append(FunctionStage(
@@ -381,7 +409,7 @@ def create_cmake_clean_job(
     return Job(
         jid=package.name,
         deps=dependencies,
-        env_loader=get_env_loader(package, context),
+        env=job_env,
         stages=stages)
 
 

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -218,7 +218,7 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
     # Environment dictionary for the job, which will be built
-    # up by the executions in the getenv stage.
+    # up by the executions in the loadenv stage.
     job_env = dict(os.environ)
 
     # Get actual staging path
@@ -353,24 +353,11 @@ def create_cmake_clean_job(
     build_space = context.package_build_space(package)
     # Package metadata path
     metadata_path = context.package_metadata_path(package)
-    # Environment dictionary for the job, which will be built
-    # up by the executions in the getenv stage.
-    job_env = dict(os.environ)
+    # Environment dictionary for the job, empty for a clean job
+    job_env = {}
 
-    # Create job stages
     stages = []
 
-    # Get environment for job.
-    stages.append(FunctionStage(
-        'getenv',
-        load_env,
-        locked_resource='installspace',
-        job_env=job_env,
-        package=package,
-        context=context
-    ))
-
-    # Remove installed files
     if clean_install and context.install:
         installed_files = get_installed_files(context.package_metadata_path(package))
         stages.append(FunctionStage(

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -31,7 +31,7 @@ from .commands.cmake import get_installed_files
 from .commands.make import MAKE_EXEC
 
 from .utils import copyfiles
-from .utils import load_env
+from .utils import loadenv
 from .utils import makedirs
 from .utils import rmfiles
 
@@ -228,10 +228,10 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
     # Create job stages
     stages = []
 
-    # Get environment for job.
+    # Load environment for job.
     stages.append(FunctionStage(
-        'getenv',
-        load_env,
+        'loadenv',
+        loadenv,
         locked_resource='installspace',
         job_env=job_env,
         package=package,

--- a/catkin_tools/jobs/utils.py
+++ b/catkin_tools/jobs/utils.py
@@ -50,7 +50,7 @@ def get_env_loaders(package, context):
     return sources
 
 
-def load_env(logger, event_queue, job_env, package, context):
+def loadenv(logger, event_queue, job_env, package, context):
     # Get the paths to the env loaders
     env_loader_paths = get_env_loaders(package, context)
     # If DESTDIR is set, set _CATKIN_SETUP_DIR as well

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -48,7 +48,7 @@ from catkin_tools.context import Context
 
 import catkin_tools.execution.job_server as job_server
 
-from catkin_tools.jobs.utils import get_env_loader
+from catkin_tools.jobs.utils import load_env
 
 from catkin_tools.metadata import find_enclosing_workspace
 from catkin_tools.metadata import get_metadata
@@ -228,7 +228,8 @@ def print_build_env(context, package_name):
     # Load the environment used by this package for building
     for pth, pkg in workspace_packages.items():
         if pkg.name == package_name:
-            environ = get_env_loader(pkg, context)(os.environ)
+            environ = dict(os.environ)
+            load_env(None, None, environ, pkg, context)
             print(format_env_dict(environ))
             return 0
     print('[build] Error: Package `{}` not in workspace.'.format(package_name),

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -48,7 +48,7 @@ from catkin_tools.context import Context
 
 import catkin_tools.execution.job_server as job_server
 
-from catkin_tools.jobs.utils import load_env
+from catkin_tools.jobs.utils import loadenv
 
 from catkin_tools.metadata import find_enclosing_workspace
 from catkin_tools.metadata import get_metadata
@@ -229,7 +229,7 @@ def print_build_env(context, package_name):
     for pth, pkg in workspace_packages.items():
         if pkg.name == package_name:
             environ = dict(os.environ)
-            load_env(None, None, environ, pkg, context)
+            loadenv(None, None, environ, pkg, context)
             print(format_env_dict(environ))
             return 0
     print('[build] Error: Package `{}` not in workspace.'.format(package_name),


### PR DESCRIPTION
This is the solution to #378 proposed in https://github.com/catkin/catkin_tools/issues/378#issuecomment-234326048.

There's probably a small perf hit here which could be mitigated by going to a readers-writer lock, but it doesn't seem Python has one natively ([example implementation](https://gist.github.com/lemiant/10660092)), and the cost of switching the locked_resource scheme to support such a thing would increase complexity. Given how fast the loadenv stage is relative to the rest of the build, I don't feel it's worth it.

@jbohren @wjwwood 

---

My validation methodology for this is as described in https://github.com/catkin/catkin_tools/issues/378#issuecomment-234239067, with one small change— I've duplicated the test workspace and am running two instances of it in parallel, in the hopes of increasing overall entropy on the box and triggering problems.

As of July 24th, I've built ros_base ~2000 times across the two workspaces, with no failed builds. Previous tests with catkin_tools 0.4.2 get failures of the ros_base workspace every 100-200 builds (we see them much more frequently than this on our bundle builds, but those are much larger and more heavily parallelized than the ros_base workspace is).

---

Upon switching back to the master branch (4f5fa9dc318f2245dd249a738c44cd3e9a317ad3), I got the following failures in my two test ros_base workspaces. **The error outputs below are manifestations of the underlying concurrency problem which this PR corrects.**

Run 11 in the first workspace:

```
Errors     << shape_msgs:cmake /home/mpurvis/catkin_tools_fail/logs/shape_msgs/build.cmake.000.log
CMake Warning at /opt/clearpath/2.1devel/sdk/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "geometry_msgs"
  with any of the following names:

    geometry_msgsConfig.cmake
    geometry_msgs-config.cmake

  Add the installation prefix of "geometry_msgs" to CMAKE_PREFIX_PATH or set
  "geometry_msgs_DIR" to a directory containing one of the above files.  If
  "geometry_msgs" provides a separate development package or SDK, be sure it
  has been installed.
```

Run 107 in the second workspace:

```
Errors     << sensor_msgs:cmake /home/mpurvis/catkin_tools_fail2/logs/sensor_msgs/build.cmake.000.log
Traceback (most recent call last):
  File "/home/mpurvis/catkin_tools_fail2/build/sensor_msgs/catkin_generated/generate_cached_setup.py", line 20, in <module>
    from catkin.environment_cache import generate_environment_script
ImportError: No module named catkin.environment_cache
```

Next failure on the 22nd run:

```
/usr/bin/python: can't open file '/home/mpurvis/catkin_tools_fail2/install/_setup_util.py': [Errno 2] No such file or directory
Finished  <<< mk                                   [ 2.0 seconds ]
Starting  >>> geometry_msgs
Starting  >>> rosgraph_msgs
______________________________________________________________________________________
Errors     << diagnostic_msgs:cmake /home/mpurvis/catkin_tools_fail2/logs/diagnostic_msgs/build.cmake.000.log
Traceback (most recent call last):
  File "/home/mpurvis/catkin_tools_fail2/build/diagnostic_msgs/catkin_generated/generate_cached_setup.py", line 20, in <module>
    from catkin.environment_cache import generate_environment_script
ImportError: No module named catkin.environment_cache
```

Then run 59:

```
Starting  >>> sensor_msgs
Starting  >>> shape_msgs
Starting  >>> trajectory_msgs
Starting  >>> visualization_msgs
sh: 0: Can't open /home/mpurvis/catkin_tools_fail/install/env.sh
WARNING: Sourced environment from `/home/mpurvis/catkin_tools_fail/install/env.sh` has no environment variables. Something is wrong.
Finished  <<< rosconsole                           [ 8.7 seconds ]
Starting  >>> pluginlib
Starting  >>> rosconsole_bridge
Starting  >>> roscpp
Finished  <<< roslisp                              [ 1.8 seconds ]
______________________________________________________________________________________
Errors     << trajectory_msgs:cmake /home/mpurvis/catkin_tools_fail/logs/trajectory_msgs/build.cmake.000.log
CMake Warning at /opt/clearpath/2.1devel/sdk/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by
  "message_generation" with any of the following names:

    message_generationConfig.cmake
    message_generation-config.cmake
```
