### PR TITLE
drop utf-8 encoding to compute file hashes in symlink stage

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -288,8 +288,8 @@ def link_devel_products(
             if os.path.exists(dest_file):
                 if os.path.realpath(dest_file) != os.path.realpath(source_file):
                     # Compute hashes for colliding files
-                    source_hash = md5(open(os.path.realpath(source_file)).read()).hexdigest()
-                    dest_hash = md5(open(os.path.realpath(dest_file)).read()).hexdigest()
+                    source_hash = md5(open(os.path.realpath(source_file), "rb").read()).hexdigest()
+                    dest_hash = md5(open(os.path.realpath(dest_file), "rb").read()).hexdigest()
                     # If the link links to a different file, report a warning and increment
                     # the collision counter for this path
                     if dest_hash != source_hash:

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -288,8 +288,8 @@ def link_devel_products(
             if os.path.exists(dest_file):
                 if os.path.realpath(dest_file) != os.path.realpath(source_file):
                     # Compute hashes for colliding files
-                    source_hash = md5(open(os.path.realpath(source_file)).read().encode('utf-8')).hexdigest()
-                    dest_hash = md5(open(os.path.realpath(dest_file)).read().encode('utf-8')).hexdigest()
+                    source_hash = md5(open(os.path.realpath(source_file)).read()).hexdigest()
+                    dest_hash = md5(open(os.path.realpath(dest_file)).read()).hexdigest()
                     # If the link links to a different file, report a warning and increment
                     # the collision counter for this path
                     if dest_hash != source_hash:

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -65,7 +65,7 @@ def get_resultspace_environment(result_space_path, base_env=None, quiet=False, c
     env_hooks_path = os.path.join(result_space_path, 'etc', 'catkin', 'profile.d')
     if os.path.exists(env_hooks_path):
         env_hooks = [
-            md5(open(os.path.join(env_hooks_path, path)).read().encode('utf-8')).hexdigest()
+            md5(open(os.path.join(env_hooks_path, path), "rb").read()).hexdigest()
             for path in os.listdir(env_hooks_path)]
     else:
         env_hooks = []


### PR DESCRIPTION
This fixes #311 (UnicodeDecodeErrors) as pointed out in https://github.com/catkin/catkin_tools/issues/311#issuecomment-224572400. Relates to #368.
