### PR TITLE
Use ioctl() to determine width of controlling terminal

### DIFF
--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -400,6 +400,19 @@ def log(*args, **kwargs):
             unicode_error_printed = True
 
 
+__warn_terminal_width_once_has_printed = False
+
+
+def __warn_terminal_width_once():
+    global __warn_terminal_width_once_has_printed
+    if __warn_terminal_width_once_has_printed:
+        return
+    __warn_terminal_width_once_has_printed = True
+    print('WARNING: Could not determine the width of the terminal. '
+          'This warning will only be printed once.',
+          file=sys.stderr)
+
+
 def terminal_width_windows():
     """Returns the estimated width of the terminal on Windows"""
     from ctypes import windll, create_string_buffer
@@ -409,6 +422,7 @@ def terminal_width_windows():
 
     # return default size if actual size can't be determined
     if not res:
+        __warn_terminal_width_once()
         return 80
 
     import struct
@@ -429,6 +443,7 @@ def terminal_width_linux():
             height, width = struct.unpack("hh", ioctl(f.fileno(), TIOCGWINSZ, "1234"))
     except (IOError, OSError, struct.error):
         # return default size if actual size can't be determined
+        __warn_terminal_width_once()
         return 80
     return width
 

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -420,9 +420,16 @@ def terminal_width_windows():
 
 def terminal_width_linux():
     """Returns the estimated width of the terminal on linux"""
-    width = subprocess.Popen('tput cols', shell=True, stdout=subprocess.PIPE, close_fds=False).stdout.readline()
-
-    return int(width)
+    from fcntl import ioctl
+    from termios import TIOCGWINSZ
+    import struct
+    try:
+        with open(os.ctermid(), "rb") as f:
+            height, width = struct.unpack("hh", ioctl(f.fileno(), TIOCGWINSZ, "1234"))
+    except (IOError, OSError, struct.error):
+        # return default size if actual size can't be determined
+        return 80
+    return width
 
 
 def terminal_width():

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -408,7 +408,8 @@ def __warn_terminal_width_once():
     if __warn_terminal_width_once_has_printed:
         return
     __warn_terminal_width_once_has_printed = True
-    print('WARNING: Could not determine the width of the terminal. '
+    print('NOTICE: Could not determine the width of the terminal. '
+          'A default width of 80 will be used. '
           'This warning will only be printed once.',
           file=sys.stderr)
 

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -18,7 +18,6 @@ import datetime
 import errno
 import os
 import re
-import subprocess
 import sys
 
 import trollius as asyncio
@@ -158,6 +157,7 @@ def format_time_delta_short(delta):
     msg += "" if len(msg) == 0 and int(minutes) == 0 else (minutes + ":")
     msg += ("{0:.1f}" if len(msg) == 0 and int(minutes) == 0 else "{0:04.1f}").format(float(seconds))
     return msg
+
 
 __recursive_build_depends_cache = {}
 
@@ -373,6 +373,7 @@ def is_tty(stream):
     """Returns True if the given stream is a tty, else False"""
     return hasattr(stream, 'isatty') and stream.isatty()
 
+
 unicode_error_printed = False
 unicode_sanitizer = re.compile(r'[^\x00-\x7F]+')
 
@@ -439,6 +440,7 @@ def terminal_width():
     except ValueError:
         # Failed to get the width, use the default 80
         return 80
+
 
 _ansi_escape = re.compile(r'\x1b[^m]*m')
 
@@ -534,6 +536,7 @@ def __wide_log(msg, **kwargs):
         log(msg + (' ' * (width - msg_len - rhs_len - 1)) + rhs, **kwargs)
     else:
         log(msg, **kwargs)
+
 
 wide_log_fn = __wide_log
 

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -82,6 +82,7 @@ def fixed__ArgumentGroup___init__(self, container, title=None, description=None,
     # Make sure this line is run, maybe redundant on versions which already have it
     self._mutually_exclusive_groups = container._mutually_exclusive_groups
 
+
 # Monkey patch in the fixed constructor
 argparse._ArgumentGroup.__init__ = fixed__ArgumentGroup___init__
 


### PR DESCRIPTION
This PR gets rid of the `tput cols` subprocess, which is slow and pollutes log files with `tput: No value for $TERM and no -T specified` messages if no controlling terminal is present.
