### PR TITLE
Modified catkin_shell_verbs for zsh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,6 @@
 language: generic
 matrix:
   include:
-    - dist: precise
-      python: 2.7
-      language: python
-      python: "2.7"
-      os: linux
-      env: PYTHON=/usr/bin/python2.7 CATKIN_VERSION=groovy-devel
-    - dist: precise
-      python: 3.4
-      language: python
-      python: "3.4"
-      os: linux
-      env: PYTHON=/usr/bin/python3.4 CATKIN_VERSION=groovy-devel
     - dist: trusty
       python: 2.7
       language: python
@@ -35,7 +23,7 @@ matrix:
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash
-  - pip install setuptools argparse catkin-pkg distribute PyYAML psutil trollius osrf_pycommon pyenchant sphinxcontrib-spelling
+  - pip install setuptools argparse catkin-pkg PyYAML psutil trollius osrf_pycommon pyenchant sphinxcontrib-spelling
 install:
   # Install catkin_tools
   - python setup.py develop

--- a/catkin_tools/verbs/catkin_shell_verbs.bash
+++ b/catkin_tools/verbs/catkin_shell_verbs.bash
@@ -80,6 +80,9 @@ function catkin() {
     esac
   done
 
+  # Pass the arguments through xargs to remove extra spaces
+  # that can be in the result in some shells, e.g. zsh.
+  # See: https://github.com/catkin/catkin_tools/pull/417
   MAIN_ARGS=$(echo "${WORKSPACE_ARGS} ${PROFILE_ARGS}" | xargs)
 
   # Get subcommand

--- a/catkin_tools/verbs/catkin_shell_verbs.bash
+++ b/catkin_tools/verbs/catkin_shell_verbs.bash
@@ -80,7 +80,7 @@ function catkin() {
     esac
   done
 
-  MAIN_ARGS="${WORKSPACE_ARGS} ${PROFILE_ARGS}"
+  MAIN_ARGS=$(echo "${WORKSPACE_ARGS} ${PROFILE_ARGS}" | xargs)
 
   # Get subcommand
   SUBCOMMAND="$1"


### PR DESCRIPTION
In zsh shell, command 
```
catkin source
```
doesn't work well.

```
 leus@callisto  /tmp  rm -rf hoge
 leus@callisto  /tmp  mkdir -p hoge/src
 leus@callisto  /tmp  cd hoge
src
 leus@callisto  /tmp/hoge  source /opt/ros/indigo/setup.zsh
 leus@callisto  /tmp/hoge  catkin init
Initializing catkin workspace in `/tmp/hoge`.
----------------------------------------------
Profile:                     default
Extending:             [env] /opt/ros/indigo
Workspace:                   /tmp/hoge
----------------------------------------------
Source Space:       [exists] /tmp/hoge/src
Log Space:         [missing] /tmp/hoge/logs
Build Space:       [missing] /tmp/hoge/build
Devel Space:       [missing] /tmp/hoge/devel
Install Space:      [unused] /tmp/hoge/install
DESTDIR:            [unused] None
----------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
----------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
----------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
----------------------------------------------
Workspace configuration appears valid.
----------------------------------------------
 leus@callisto  /tmp/hoge  cd src
 leus@callisto  /tmp/hoge/src  catkin create pkg hoge
Creating package "hoge" in "/tmp/hoge/src"...
Created file hoge/package.xml
Created file hoge/CMakeLists.txt
Successfully created package files in /tmp/hoge/src/hoge.
 leus@callisto  /tmp/hoge/src  catkin b
==> Expanding alias 'b' from 'catkin b' to 'catkin build'
----------------------------------------------
Profile:                     default
Extending:             [env] /opt/ros/indigo
Workspace:                   /tmp/hoge
----------------------------------------------
Source Space:       [exists] /tmp/hoge/src
Log Space:         [missing] /tmp/hoge/logs
Build Space:        [exists] /tmp/hoge/build
Devel Space:        [exists] /tmp/hoge/devel
Install Space:      [unused] /tmp/hoge/install
DESTDIR:            [unused] None
----------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
----------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
----------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
----------------------------------------------
Workspace configuration appears valid.

NOTE: Forcing CMake to run for each package.
----------------------------------------------
[build] Found '1' packages in 0.0 seconds.
[build] Updating package table.
Starting  >>> catkin_tools_prebuild
Finished  <<< catkin_tools_prebuild                [ 1.4 seconds ]
Starting  >>> hoge
Finished  <<< hoge                                 [ 1.3 seconds ]
[build] Summary: All 2 packages succeeded!
[build]   Ignored:   None.
[build]   Warnings:  None.
[build]   Abandoned: None.
[build]   Failed:    None.
[build] Runtime: 3.0 seconds total.
[build] Note: Workspace packages have changed, please re-source setup files to use them.
 leus@callisto  /tmp/hoge/src  catkin source
catkin:source:61: no such file or directory: /tmp/hoge/devel/share/ /setup.zsh
```

This is because zsh's variable can contain space.
in bash
```
[http://hrp2017v:10017][192.168.96.184] leus@callisto:/tmp/hoge/src$ export HOGE=" "
[http://hrp2017v:10017][192.168.96.184] leus@callisto:/tmp/hoge/src$ echo -n $HOGE | wc -m
0
```
in zsh
```
 leus@callisto  /tmp/hoge/src  export HOGE=" "
 leus@callisto  /tmp/hoge/src  echo -n $HOGE | wc -m
1
```
To trim space only string, I added piping by xargs.
