### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ catkin_pkg
 osrf_pycommon
 pyyaml
 setuptools
-sphinxcontrib-ansi
 sphinxcontrib-programoutput
 trollius


### PR DESCRIPTION
fix https://github.com/catkin/catkin_tools/issues/431: cannot build: Could not find a version that satisfies the requirement sphinxcontrib-ansi #4