### PR TITLE
Correctly merge envvars from isolated workspaces.

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -380,7 +380,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
     stages.append(FunctionStage(
         'loadenv',
         loadenv,
-        locked_resource='installspace',
+        locked_resource=None if context.isolate_install else 'installspace',
         job_env=job_env,
         package=package,
         context=context
@@ -504,7 +504,7 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
             [MAKE_EXEC, 'install'],
             cwd=build_space,
             logger_factory=CMakeMakeIOBufferProtocol.factory,
-            locked_resource='installspace'
+            locked_resource=None if context.isolate_install else 'installspace'
         ))
 
     return Job(

--- a/catkin_tools/jobs/utils.py
+++ b/catkin_tools/jobs/utils.py
@@ -82,7 +82,8 @@ def loadenv(logger, event_queue, job_env, package, context):
     for key, new_values_set in updated_env.items():
         if key in job_env:
             prepend_values = new_values_set - set(job_env[key].split(':'))
-            job_env[key] = ':'.join(prepend_values) + ':' + job_env[key]
+            if prepend_values:
+                job_env[key] = ':'.join(prepend_values) + ':' + job_env[key]
         else:
             job_env[key] = ':'.join(new_values_set)
     return 0


### PR DESCRIPTION
Fixes #382. With this change, isolated devel and isolated install spaces both do the right thing:

```
rosinstall_generator --rosdistro indigo roscpp --deps --tar > roscpp.rosinstall
rosinstall src roscpp.rosinstall -j8
catkin config --isolate-install --isolate-devel --install  # or --no-install
catkin build
```

For packages with many dependencies, the `loadenv` stage can end up taking a nontrivial amount of time, since it's invoking as many `env.sh` instances as there are dependencies. However, this can be mitigated by using the `--env-cache` config option.

@wjwwood @jbohren 