### PR TITLE
Specify return code when build interrupted.

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -576,6 +576,8 @@ def build_isolated_workspace(
     except KeyboardInterrupt:
         wide_log("[build] Interrupted by user!")
         event_queue.put(None)
+        
+        return 130  # EOWNERDEAD return code is not part of the errno module.
 
 
 def _create_unmerged_devel_setup(context, unbuilt):

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -576,7 +576,7 @@ def build_isolated_workspace(
     except KeyboardInterrupt:
         wide_log("[build] Interrupted by user!")
         event_queue.put(None)
-        
+
         return 130  # EOWNERDEAD return code is not part of the errno module.
 
 


### PR DESCRIPTION
The main alternative here might be to return `errno.EINTR`, which evaluates to 4 on at least Linux and OS X. However, interrupting other common command line utilities on both platforms seems to always yield a 130:

```
$ find /
.
.
.
^C
$ echo $?
130
```

Same with `cat`:

```
$ cat
^C
$ echo $?
130
```