### PR TITLE
Better message when missing a required command line tool.

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -37,6 +37,7 @@ from .commands.make import MAKE_EXEC
 from .utils import copyfiles
 from .utils import loadenv
 from .utils import makedirs
+from .utils import require_command
 from .utils import rmfiles
 
 
@@ -432,6 +433,8 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
             prefix=context.package_dest_path(package)
         ))
 
+        require_command('cmake', CMAKE_EXEC)
+
         # CMake command
         stages.append(CommandStage(
             'cmake',
@@ -472,6 +475,8 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
             [MAKE_EXEC, 'clean'] + make_args,
             cwd=build_space,
         ))
+
+    require_command('make', MAKE_EXEC)
 
     # Make command
     stages.append(CommandStage(

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -33,6 +33,7 @@ from .commands.make import MAKE_EXEC
 from .utils import copyfiles
 from .utils import loadenv
 from .utils import makedirs
+from .utils import require_command
 from .utils import rmfiles
 
 from catkin_tools.execution.jobs import Job
@@ -260,6 +261,8 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
         dest_path=os.path.join(metadata_path, 'package.xml')
     ))
 
+    require_command('cmake', CMAKE_EXEC)
+
     # CMake command
     makefile_path = os.path.join(build_space, 'Makefile')
     if not os.path.isfile(makefile_path) or force_cmake:
@@ -290,6 +293,8 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
             [MAKE_EXEC, 'clean'] + make_args,
             cwd=build_space,
         ))
+
+    require_command('make', MAKE_EXEC)
 
     # Make command
     stages.append(CommandStage(

--- a/catkin_tools/jobs/utils.py
+++ b/catkin_tools/jobs/utils.py
@@ -25,6 +25,19 @@ from catkin_tools.resultspace import get_resultspace_environment
 from catkin_tools.execution.events import ExecutionEvent
 
 
+class CommandMissing(Exception):
+    '''A required command is missing.'''
+
+    def __init__(self, name):
+        super(CommandMissing, self).__init__(
+                'Cannot find required tool `%s` on the PATH, is it installed?' % name)
+
+
+def require_command(name, which):
+    if not which:
+        raise CommandMissing(name)
+
+
 def get_env_loaders(package, context):
     """Get a list of env loaders required to build this package."""
 

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -48,6 +48,7 @@ from catkin_tools.context import Context
 
 import catkin_tools.execution.job_server as job_server
 
+from catkin_tools.jobs.utils import CommandMissing
 from catkin_tools.jobs.utils import loadenv
 
 from catkin_tools.metadata import find_enclosing_workspace
@@ -400,22 +401,25 @@ def main(opts):
     if opts.verbose:
         os.environ['VERBOSE'] = '1'
 
-    return build_isolated_workspace(
-        ctx,
-        packages=opts.packages,
-        start_with=opts.start_with,
-        no_deps=opts.no_deps,
-        unbuilt=opts.unbuilt,
-        n_jobs=parallel_jobs,
-        force_cmake=opts.force_cmake,
-        pre_clean=opts.pre_clean,
-        force_color=opts.force_color,
-        quiet=not opts.verbose,
-        interleave_output=opts.interleave_output,
-        no_status=opts.no_status,
-        limit_status_rate=opts.limit_status_rate,
-        lock_install=not opts.no_install_lock,
-        no_notify=opts.no_notify,
-        continue_on_failure=opts.continue_on_failure,
-        summarize_build=opts.summarize  # Can be True, False, or None
-    )
+    try:
+        return build_isolated_workspace(
+            ctx,
+            packages=opts.packages,
+            start_with=opts.start_with,
+            no_deps=opts.no_deps,
+            unbuilt=opts.unbuilt,
+            n_jobs=parallel_jobs,
+            force_cmake=opts.force_cmake,
+            pre_clean=opts.pre_clean,
+            force_color=opts.force_color,
+            quiet=not opts.verbose,
+            interleave_output=opts.interleave_output,
+            no_status=opts.no_status,
+            limit_status_rate=opts.limit_status_rate,
+            lock_install=not opts.no_install_lock,
+            no_notify=opts.no_notify,
+            continue_on_failure=opts.continue_on_failure,
+            summarize_build=opts.summarize  # Can be True, False, or None
+        )
+    except CommandMissing as e:
+        sys.exit(clr("[build] @!@{rf}Error:@| {0}").format(e))


### PR DESCRIPTION
Looks like this:

```
$ catkin build
----------------------------------------------------------------
Profile:                     default
Extending:          [cached] /Users/mikepurvis/config_ws/install
Workspace:                   /Users/mikepurvis/config_ws
----------------------------------------------------------------
Source Space:       [exists] /Users/mikepurvis/config_ws/src
Log Space:          [exists] /Users/mikepurvis/config_ws/logs
Build Space:        [exists] /Users/mikepurvis/config_ws/build
Devel Space:        [exists] /Users/mikepurvis/config_ws/devel
Install Space:      [exists] /Users/mikepurvis/config_ws/install
DESTDIR:            [unused] None
----------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        merged
----------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
----------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
----------------------------------------------------------------
Workspace configuration appears valid.
----------------------------------------------------------------
[build] Found '6' packages in 0.0 seconds.                                                                                
[build] Error: Cannot find required tool `make` on the PATH, is it installed?
```

Fixes #437.