### PR TITLE
Implementation of pluggable spaces.

### DIFF
--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -89,7 +89,7 @@ def add_cmake_and_make_and_catkin_make_args(parser):
 
     add = parser.add_mutually_exclusive_group().add_argument
     add('--make-args', metavar='ARG', dest='make_args', nargs='+', required=False, type=str, default=None,
-        help='Arbitrary arguments which are passes to make.'
+        help='Arbitrary arguments which are passes to make. '
              'It collects all of following arguments until a "--" is read.')
     add('--no-make-args', dest='make_args', action='store_const', const=[], default=None,
         help='Pass no additional arguments to make (does not affect --catkin-make-args).')
@@ -97,7 +97,7 @@ def add_cmake_and_make_and_catkin_make_args(parser):
     add = parser.add_mutually_exclusive_group().add_argument
     add('--catkin-make-args', metavar='ARG', dest='catkin_make_args',
         nargs='+', required=False, type=str, default=None,
-        help='Arbitrary arguments which are passes to make but only for catkin packages.'
+        help='Arbitrary arguments which are passes to make but only for catkin packages. '
              'It collects all of following arguments until a "--" is read.')
     add('--no-catkin-make-args', dest='catkin_make_args', action='store_const', const=[], default=None,
         help='Pass no additional arguments to make for catkin packages (does not affect --make-args).')

--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -82,14 +82,14 @@ def add_cmake_and_make_and_catkin_make_args(parser):
 
     add = parser.add_mutually_exclusive_group().add_argument
     add('--cmake-args', metavar='ARG', dest='cmake_args', nargs='+', required=False, type=str, default=None,
-        help='Arbitrary arguments which are passes to CMake. '
+        help='Arbitrary arguments which are passed to CMake. '
              'It collects all of following arguments until a "--" is read.')
     add('--no-cmake-args', dest='cmake_args', action='store_const', const=[], default=None,
         help='Pass no additional arguments to CMake.')
 
     add = parser.add_mutually_exclusive_group().add_argument
     add('--make-args', metavar='ARG', dest='make_args', nargs='+', required=False, type=str, default=None,
-        help='Arbitrary arguments which are passes to make. '
+        help='Arbitrary arguments which are passed to make. '
              'It collects all of following arguments until a "--" is read.')
     add('--no-make-args', dest='make_args', action='store_const', const=[], default=None,
         help='Pass no additional arguments to make (does not affect --catkin-make-args).')
@@ -97,7 +97,7 @@ def add_cmake_and_make_and_catkin_make_args(parser):
     add = parser.add_mutually_exclusive_group().add_argument
     add('--catkin-make-args', metavar='ARG', dest='catkin_make_args',
         nargs='+', required=False, type=str, default=None,
-        help='Arbitrary arguments which are passes to make but only for catkin packages. '
+        help='Arbitrary arguments which are passed to make but only for catkin packages. '
              'It collects all of following arguments until a "--" is read.')
     add('--no-catkin-make-args', dest='catkin_make_args', action='store_const', const=[], default=None,
         help='Pass no additional arguments to make for catkin packages (does not affect --make-args).')

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -91,7 +91,9 @@ class Context(object):
             setattr(self, '__%s_space_abs' % space, os.path.join(self.__workspace, value))
 
         def space_exists(self):
-            "Returns true if the space exists"
+            """
+            Returns true if the space exists.
+            """
             space_abs = getattr(self, '__%s_space_abs' % space)
             return os.path.exists(space_abs) and os.path.isdir(space_abs)
 
@@ -101,11 +103,11 @@ class Context(object):
 
     @classmethod
     def setup_space_keys(cls):
-        '''
+        """
         To be called one time on initial use. Initializes the SPACE_KEYS
         class members and associated member functions based on available
         space plugins.
-        '''
+        """
         if cls.KEYS:
             return
 

--- a/catkin_tools/spaces/build.py
+++ b/catkin_tools/spaces/build.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description = dict(
+    default='build',
+    short_flag='-b',
+    space='Build Space',
+    description='Intermediate generated files are placed in this location.'
+)

--- a/catkin_tools/spaces/devel.py
+++ b/catkin_tools/spaces/devel.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description = dict(
+    default='devel',
+    short_flag='-d',
+    space='Devel Space',
+    description='This result space contains compiled products but ' +
+    'references the source space for static assets and scripts.'
+)

--- a/catkin_tools/spaces/install.py
+++ b/catkin_tools/spaces/install.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description = dict(
+    default='install',
+    short_flag='-i',
+    space='Install Space',
+    description='Self-contained installation result space.'
+)

--- a/catkin_tools/spaces/log.py
+++ b/catkin_tools/spaces/log.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description = dict(
+    default='logs',
+    short_flag='-l',
+    space='Log Space',
+    description='Output generated during the build stages.'
+)

--- a/catkin_tools/spaces/source.py
+++ b/catkin_tools/spaces/source.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description = dict(
+    default='src',
+    short_flag='-s',
+    space='Source Space',
+    description='Source files, should not be modified by build system.'
+)

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -75,36 +75,16 @@ def prepare_arguments(parser):
         help='Clear all packages from the blacklist.')
 
     spaces_group = parser.add_argument_group('Spaces', 'Location of parts of the catkin workspace.')
-    add = spaces_group.add_mutually_exclusive_group().add_argument
-    add('-s', '--source-space', default=None,
-        help='The path to the source space.')
-    add('--default-source-space',
-        action='store_const', dest='source_space', default=None, const=Context.DEFAULT_SOURCE_SPACE,
-        help='Use the default path to the source space ("src")')
-    add = spaces_group.add_mutually_exclusive_group().add_argument
-    add('-l', '--log-space', default=None,
-        help='The path to the log space.')
-    add('--default-log-space',
-        action='store_const', dest='log_space', default=None, const=Context.DEFAULT_LOG_SPACE,
-        help='Use the default path to the log space ("logs")')
-    add = spaces_group.add_mutually_exclusive_group().add_argument
-    add('-b', '--build-space', default=None,
-        help='The path to the build space.')
-    add('--default-build-space',
-        action='store_const', dest='build_space', default=None, const=Context.DEFAULT_BUILD_SPACE,
-        help='Use the default path to the build space ("build")')
-    add = spaces_group.add_mutually_exclusive_group().add_argument
-    add('-d', '--devel-space', default=None,
-        help='Sets the target devel space')
-    add('--default-devel-space',
-        action='store_const', dest='devel_space', default=None, const=Context.DEFAULT_DEVEL_SPACE,
-        help='Sets the default target devel space ("devel")')
-    add = spaces_group.add_mutually_exclusive_group().add_argument
-    add('-i', '--install-space', default=None,
-        help='Sets the target install space')
-    add('--default-install-space',
-        action='store_const', dest='install_space', default=None, const=Context.DEFAULT_INSTALL_SPACE,
-        help='Sets the default target install space ("install")')
+    Context.setup_space_keys()
+    for space, space_dict in Context.SPACES.items():
+        add = spaces_group.add_mutually_exclusive_group().add_argument
+        flags = ['--{}-space'.format(space)]
+        flags.extend([space_dict['short_flag']] if 'short_flag' in space_dict else [])
+        add(*flags, default=None,
+            help='The path to the {} space.'.format(space))
+        add('--default-{}-space'.format(space),
+            action='store_const', dest='{}_space'.format(space), default=None, const=space_dict['default'],
+            help='Use the default path to the {} space ("{}")'.format(space, space_dict['default']))
     add = spaces_group.add_argument
     add('-x', '--space-suffix',
         help='Suffix for build, devel, and install space if they are not otherwise explicitly set.')

--- a/docs/mechanics.rst
+++ b/docs/mechanics.rst
@@ -235,7 +235,6 @@ Sourcing these setup scripts adds this workspace and any "underlaid" workspaces 
 
 .. [1] GNU/Linux Only
 .. [2] Mac OS X Only
-.. [3] Windows Only
 .. [4] Only in versions of ``catkin`` <= ``0.7.0`` (ROS Kinetic), see the changelog_
 
 

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,13 @@ setup(
             'catkin = catkin_tools.jobs.catkin:description',
             'cmake = catkin_tools.jobs.cmake:description',
         ],
+        'catkin_tools.spaces': [
+            'build = catkin_tools.spaces.build:description',
+            'devel = catkin_tools.spaces.devel:description',
+            'install = catkin_tools.spaces.install:description',
+            'log = catkin_tools.spaces.log:description',
+            'source = catkin_tools.spaces.source:description',
+        ],
     },
     cmdclass={'install': PermissiveInstall},
 )


### PR DESCRIPTION
As discussed in https://github.com/mikepurvis/catkin_tools_document/issues/3#issuecomment-301650982.

This permits plugins to register new first-class space types. Some potential candidate uses:

- A `docs` space for stashing doxygen/sphinx output.
- A `tests` space for placing junit testing reports.
- A `merge` space for placing post-build merged installspaces assembled from workspaces built with the `--install-isolated` option.
- A `symbols` space for placing debug symbols stripped from binaries during/after the the build.

I haven't yet updated the `catkin_clean` verb to take advantage of this, but will do so shortly.

FYI @wjwwood @tspicer01

----

Test failure is due to a [breakage upstream with the Sphinx spellcheck](https://bitbucket.org/dhellmann/sphinxcontrib-spelling/issues/13/with-sphinx-161-contractions-result-in). I'd suggest either turning off the spellcheck for now, or locking into an older version of Sphinx where the problem didn't happen.