### PR TITLE
Fix typo in documentation of option env-cache

### DIFF
--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -180,7 +180,7 @@ Accelerated Building with Environment Caching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each package is built in a special environment which is loaded from the current workspace and any workspaces that the current workspace is extending.
-If you are confident that your workspace's environment is not changing during a build, you can tell ``catkin build`` to cache these environments with the ``--cache-env`` option.
+If you are confident that your workspace's environment is not changing during a build, you can tell ``catkin build`` to cache these environments with the ``--env-cache`` option.
 This has the effect of dramatically reducing build times for workspaces where many packages are already built.
 
 


### PR DESCRIPTION
The text mixed up the two sub-words of the option. In the latest catkin_tools version 0.4.4, the option is named ``env-cache``, not ``cache-env``.