### PR TITLE
Fixed doc and completion based on current CLI for interleave output

### DIFF
--- a/completion/_catkin
+++ b/completion/_catkin
@@ -216,7 +216,7 @@ _catkin_build_complete() {
     '--profile[Which configuration profile to use]:profile:_catkin_get_profiles'\
     {-n,--dry-run}'[Show build process without actually building]'\
     {-v,--verbose}'[Print all output from build commands]'\
-    {-i,--interleave}"[Print output from build commands as it's generated]"\
+    {-i,--interleave-output}"[Print output from build commands as it's generated]"\
     {-c,--continue-on-failure}'[Build all selected packages even if some fail]'\
     '--get-env[Print the environment for a given workspace]:package:_catkin_get_packages'\
     '--force-cmake[Force CMake to run for each package]'\
@@ -316,7 +316,7 @@ _catkin_profile_complete() {
       ;;
     (args)
       case $line[1] in
-        (set|rename|remove) 
+        (set|rename|remove)
           local expl
           _wanted workspace_profiles expl "workspace profiles" _catkin_get_profiles && return 0
           ;;
@@ -345,7 +345,7 @@ _catkin_create_complete() {
       ;;
     (args)
       case $line[1] in
-        (pkg) 
+        (pkg)
           local pkg_opts
           pkg_opts=(\
             {-h,--help}'[Show usage help]'\
@@ -456,28 +456,28 @@ case "$state" in
     ;;
   (options)
     case $line[1] in
-      (build) _catkin_build_complete && ret=0 
+      (build) _catkin_build_complete && ret=0
         ;;
-      (clean) _catkin_clean_complete && ret=0 
+      (clean) _catkin_clean_complete && ret=0
         ;;
-      (config) 
+      (config)
         if [[ "$(_catkin_last_option)" =~ "--(black|white)list" ]]; then
           _catkin_get_packages && ret=0
         else
-          _catkin_config_complete && ret=0 
+          _catkin_config_complete && ret=0
         fi
         ;;
       (create) _catkin_create_complete && ret=0
         ;;
-      (env) _catkin_env_complete && ret=0 
+      (env) _catkin_env_complete && ret=0
         ;;
-      (init) _catkin_init_complete && ret=0 
+      (init) _catkin_init_complete && ret=0
         ;;
-      (list) _catkin_list_complete && ret=0 
+      (list) _catkin_list_complete && ret=0
         ;;
-      (locate) _catkin_locate_complete && ret=0 
+      (locate) _catkin_locate_complete && ret=0
         ;;
-      (profile) _catkin_profile_complete && ret=0 
+      (profile) _catkin_profile_complete && ret=0
         ;;
     esac
     ret=0

--- a/docs/examples/ros_tutorials_ws/5_build_i.bash
+++ b/docs/examples/ros_tutorials_ws/5_build_i.bash
@@ -1,2 +1,2 @@
 cd /tmp/ros_tutorials_ws  # Navigate to workspace
-catkin build --interleave # Build all the packages in the workspace
+catkin build --interleave-output # Build all the packages in the workspace

--- a/docs/verbs/catkin_build.rst
+++ b/docs/verbs/catkin_build.rst
@@ -129,7 +129,7 @@ This will print the normal messages when a build job starts and finishes as well
 
     <center><script type="text/javascript" src="https://asciinema.org/a/9d9jklblvvyeq62y2r3ugpywp.js" id="asciicast-9d9jklblvvyeq62y2r3ugpywp" async></script></center>
 
-All output can be printed interleaved with the ``--interleave`` option.
+All output can be printed interleaved with the ``--interleave-output`` option.
 In this case, each line is prefixed with the job and stage from which it came.
 
 .. raw:: html
@@ -172,7 +172,7 @@ Consider a Catkin workspace with a **source space** populated with the following
 Building Specific Packages
 --------------------------
 
-Specific packages can also be built by specifying them as positional arguments after the ``build`` verb: 
+Specific packages can also be built by specifying them as positional arguments after the ``build`` verb:
 
 .. literalinclude:: ../examples/ros_tutorials_ws/6_build_partial.bash
    :language: bash
@@ -187,7 +187,7 @@ Context-Aware Building
 ----------------------
 
 In addition to building all packages or specified packages with various dependency requirements, ``catkin build`` can also determine the package containing the current working directory.
-This is equivalent to specifying the name of the package on the command line, and is done by passing the ``--this`` option to ``catkin build`` like the following: 
+This is equivalent to specifying the name of the package on the command line, and is done by passing the ``--this`` option to ``catkin build`` like the following:
 
 .. literalinclude:: ../examples/ros_tutorials_ws/7_build_this.bash
    :language: bash
@@ -336,13 +336,13 @@ This flag requires installing the Python ``psutil`` module and is useful on syst
 
 Memory is specified either by percent or by the number of bytes.
 
-For example, to specify that ``catkin build`` should not start additional parallel jobs when 50% of the available memory is used, you could run: 
+For example, to specify that ``catkin build`` should not start additional parallel jobs when 50% of the available memory is used, you could run:
 
 .. code-block:: bash
 
     $ catkin build --mem-limit 50%
 
-Alternatively, if it should not start additional jobs when over 4GB of memory is used, you can specify: 
+Alternatively, if it should not start additional jobs when over 4GB of memory is used, you can specify:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The current CLI for the interleave output proposes to use --interleave-output instead of --interleave.
In addition some trailing whitespaces were removed.