### PR TITLE
Add trollius to setup.py `install_requires` list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'setuptools',
     'PyYAML',
     'osrf-pycommon > 0.1.1',
+    'trollius'
 ]
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     install_requires.append('argparse')


### PR DESCRIPTION
closes issue #445
This patch can be viewed as continuing the work of pull request #282