### PR TITLE
Enable arguments with spaces in alias definition

### DIFF
--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -19,6 +19,7 @@ from datetime import date
 import os
 import pkg_resources
 import sys
+import pipes
 
 from catkin_tools.common import is_tty
 
@@ -103,7 +104,7 @@ def expand_one_verb_alias(sysargs, verb_aliases, used_aliases):
         if arg in verb_aliases:
             before = [] if index == 0 else sysargs[:index - 1]
             after = [] if index == len(sysargs) else sysargs[index + 1:]
-            sysargs[:] = before + verb_aliases[arg].split() + after
+            sysargs[:] = before + verb_aliases[arg] + after
             print(fmt(
                 "@!@{gf}==>@| Expanding alias "
                 "'@!@{yf}{alias}@|' "
@@ -111,7 +112,7 @@ def expand_one_verb_alias(sysargs, verb_aliases, used_aliases):
                 "to '@{yf}{before} @!{expansion}@{boldoff}{after}@|'"
             ).format(
                 alias=arg,
-                expansion=verb_aliases[arg],
+                expansion=' '.join([pipes.quote(aarg) for aarg in verb_aliases[arg]]),
                 before=' '.join([cmd] + before),
                 after=(' '.join([''] + after) if after else '')
             ))
@@ -213,7 +214,7 @@ def catkin_main(sysargs):
     for arg in sysargs:
         if arg == '--list-aliases' or arg == '-a':
             for alias in sorted(list(verb_aliases.keys())):
-                print("{0}: {1}".format(alias, verb_aliases[alias]))
+                print("{0}: {1}".format(alias, ' '.join([pipes.quote(aarg) for aarg in verb_aliases[alias]])))
             sys.exit(0)
         if not arg.startswith('-'):
             break

--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -19,7 +19,11 @@ from datetime import date
 import os
 import pkg_resources
 import sys
-import pipes
+
+try:
+    from shlex import quote as cmd_quote
+except ImportError:
+    from pipes import quote as cmd_quote
 
 from catkin_tools.common import is_tty
 
@@ -112,7 +116,7 @@ def expand_one_verb_alias(sysargs, verb_aliases, used_aliases):
                 "to '@{yf}{before} @!{expansion}@{boldoff}{after}@|'"
             ).format(
                 alias=arg,
-                expansion=' '.join([pipes.quote(aarg) for aarg in verb_aliases[arg]]),
+                expansion=' '.join([cmd_quote(aarg) for aarg in verb_aliases[arg]]),
                 before=' '.join([cmd] + before),
                 after=(' '.join([''] + after) if after else '')
             ))
@@ -214,7 +218,7 @@ def catkin_main(sysargs):
     for arg in sysargs:
         if arg == '--list-aliases' or arg == '-a':
             for alias in sorted(list(verb_aliases.keys())):
-                print("{0}: {1}".format(alias, ' '.join([pipes.quote(aarg) for aarg in verb_aliases[alias]])))
+                print("{0}: {1}".format(alias, ' '.join([cmd_quote(aarg) for aarg in verb_aliases[alias]])))
             sys.exit(0)
         if not arg.startswith('-'):
             break

--- a/catkin_tools/config.py
+++ b/catkin_tools/config.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import os
 import yaml
+import shlex
 
 from .common import string_type
 
@@ -100,11 +101,18 @@ def get_verb_aliases(path=catkin_config_path):
                 if not isinstance(key, string_type):
                     raise RuntimeError("Invalid alias in file ('{0}'), expected a string but got '{1}' of type {2}"
                                        .format(full_path, key, type(key)))
-                if not isinstance(value, string_type) and not isinstance(value, type(None)):
+                parsed_value = None
+                if isinstance(value, string_type):
+                    # Parse using shlex
+                    parsed_value = shlex.split(value)
+                elif isinstance(value, list) or isinstance(value, type(None)):
+                    # Take plainly
+                    parsed_value = value
+                else:
                     raise RuntimeError(
-                        "Invalid alias expansion in file ('{0}'), expected a string but got '{1}' of type {2}"
+                        "Invalid alias expansion in file ('{0}'), expected a string or a list but got '{1}' of type {2}"
                         .format(full_path, value, type(value)))
-            verb_aliases.update(yaml_dict)
+                verb_aliases[key] = parsed_value
     for alias, value in dict(verb_aliases).items():
         if not value:
             del verb_aliases[alias]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -87,7 +87,7 @@ ls: null
 """)
     aliases = config.get_verb_aliases(test_folder)
     assert 'b' in aliases
-    assert aliases['b'] == 'build --isolate-devel', aliases['b']
+    assert aliases['b'] == ['build', '--isolate-devel'], aliases['b']
     assert 'ls' not in aliases
     # Test a bad alias files
     bad_path = os.path.join(base_path, '02-bad.yaml')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,7 +77,7 @@ def test_get_verb_aliases():
     config.initialize_config(test_folder)
     aliases = config.get_verb_aliases(test_folder)
     assert 'b' in aliases
-    assert aliases['b'] == 'build'
+    assert aliases['b'] == ['build']
     # Test a custom file
     base_path = os.path.join(test_folder, 'verb_aliases')
     with open(os.path.join(base_path, '01-my-custom-aliases.yaml'), 'w') as f:


### PR DESCRIPTION
This is the solution for #464. It supports both using quotes as understood by shlex in the string and using a yaml list to specify the single arguments.

The only downside to this is that it uses the function `pipes.quote` which is apparently deprecated. 