### PR TITLE
Treat spaces as handled config context options

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -247,6 +247,11 @@ class Context(object):
         space_suffix=None,
         whitelist=None,
         blacklist=None,
+        devel_space=None,
+        source_space=None,
+        log_space=None,
+        build_space=None,
+        install_space=None,
         **kwargs
     ):
         """Creates a new Context object, optionally initializing with parameters


### PR DESCRIPTION
Adding keyed parameters for those options inhibits the following warning when using profiles.

> Unhandled config context options: {}