### PR TITLE
Sanitizes log message input

### DIFF
--- a/catkin_tools/execution/io.py
+++ b/catkin_tools/execution/io.py
@@ -128,7 +128,7 @@ class IOBufferContainer(object):
         """Decode bytes into Python str.
         :type data: bytes
         """
-        return data.decode('utf-8')
+        return data.decode('utf-8', 'replace')
 
     def __del__(self):
         if self.is_open:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,4 +1,10 @@
-from queue import Queue
+try:
+    # Python3
+    from queue import Queue
+except ImportError:
+    # Python2
+    from Queue import Queue
+
 from catkin_tools.execution import io as io
 
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -5,12 +5,13 @@ except ImportError:
     # Python2
     from Queue import Queue
 
+import binascii
 from catkin_tools.execution import io as io
 
 
 def test_invalid_utf8_characters():
     io_container = io.IOBufferContainer('test', 'test_id', 'test', Queue(), '/tmp')
-    bad_byte_array = (128).to_bytes(1, byteorder='big')
+    bad_byte_array = binascii.a2b_hex(b'80')
     try:
         io_container._decode(bad_byte_array)
     except UnicodeDecodeError:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,0 +1,11 @@
+from queue import Queue
+from catkin_tools.execution import io as io
+
+
+def test_invalid_utf8_characters():
+    io_container = io.IOBufferContainer('test', 'test_id', 'test', Queue(), '/tmp')
+    bad_byte_array = (128).to_bytes(1, byteorder='big')
+    try:
+        io_container._decode(bad_byte_array)
+    except UnicodeDecodeError:
+        assert False, "Bad decoding"


### PR DESCRIPTION
There was an issue in which invalid utf-8 characters that appeared in test
output were causing unhandled exceptions to be raised. The fix uses
built-in sanitization features to replace invalid characters with '?'. Fixes #478 