### PR TITLE
Fixed jobserver not working with GNU make >= 4.2

### DIFF
--- a/catkin_tools/execution/job_server.py
+++ b/catkin_tools/execution/job_server.py
@@ -63,23 +63,25 @@ def memory_usage():
     return None, None
 
 
-JOBSERVER_SUPPORT_MAKEFILE = b'''
+JOBSERVER_SUPPORT_MAKEFILE_OLD = b'''
 all:
 \techo $(MAKEFLAGS) | grep -- '--jobserver-fds'
 '''
 
+JOBSERVER_SUPPORT_MAKEFILE = b'''
+all:
+\techo $(MAKEFLAGS) | grep -- '--jobserver-auth'
+'''
 
-def test_gnu_make_support():
+
+def test_gnu_make_support_common(makefile_content):
     """
-    Test if the system 'make' supports the job server implementation.
-
-    This simply checks if the `--jobserver-fds` option is supported by the
-    `make` command. It does not tests if the jobserver is actually working
-    properly.
+    Test if "make -f MAKEFILE -j2" runs successfullyn when MAKEFILE
+    contains makefile_content.
     """
 
     fd, makefile = mkstemp()
-    os.write(fd, JOBSERVER_SUPPORT_MAKEFILE)
+    os.write(fd, makefile_content)
     os.close(fd)
 
     ret = subprocess.call(['make', '-f', makefile, '-j2'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -88,13 +90,50 @@ def test_gnu_make_support():
     return (ret == 0)
 
 
+def test_gnu_make_support_old():
+    """
+    Test if the system 'make' supports the job server implementation.
+
+    This simply checks if the `--jobserver-fds` option is supported by the
+    `make` command. It does not tests if the jobserver is actually working
+    properly.
+    """
+
+    return test_gnu_make_support_common(JOBSERVER_SUPPORT_MAKEFILE_OLD)
+
+
+def test_gnu_make_support():
+    """
+    Test if the system 'make' supports the job server implementation.
+
+    This simply checks if the `--jobserver-auth` option is supported by the
+    `make` command. It does not tests if the jobserver is actually working
+    properly.
+    """
+
+    return test_gnu_make_support_common(JOBSERVER_SUPPORT_MAKEFILE)
+
+
+class GnuMake(object):
+    def __init__(self):
+        if test_gnu_make_support():
+            self.make_args = lambda job_pipe: ["--jobserver-auth=%d,%d" % JobServer._job_pipe]
+        elif test_gnu_make_support_old():
+            self.make_args = lambda job_pipe: ["--jobserver-fds=%d,%d" % JobServer._job_pipe, "-j"]
+        else:
+            self.make_args = None
+
+    def is_supported(self):
+        return not (self.make_args is None)
+
+
 class JobServer(object):
     # Whether the job server has been initialized
     _initialized = False
 
     # Flag designating whether the `make` program supports the GNU Make
     # jobserver interface
-    _gnu_make_supported = None
+    _gnu_make = None
 
     # Initialize variables
     _load_ok = True
@@ -270,10 +309,10 @@ def initialize(max_jobs=None, max_load=None, max_mem=None, gnu_make_enabled=Fals
         return
 
     # Check if the jobserver is supported
-    if JobServer._gnu_make_supported is None:
-        JobServer._gnu_make_supported = test_gnu_make_support()
+    if JobServer._gnu_make is None:
+        JobServer._gnu_make = GnuMake()
 
-    if not JobServer._gnu_make_supported:
+    if not JobServer._gnu_make.is_supported():
         log(clr('@!@{yf}WARNING:@| Make job server not supported. The number of Make '
                 'jobs may exceed the number of CPU cores.@|'))
 
@@ -398,7 +437,7 @@ def release(label=None):
 
 
 def gnu_make_enabled():
-    return JobServer._gnu_make_supported and JobServer._gnu_make_enabled
+    return JobServer._gnu_make.is_supported() and JobServer._gnu_make_enabled
 
 
 def gnu_make_args():
@@ -406,8 +445,8 @@ def gnu_make_args():
     Get required arguments for spawning child gnu Make processes.
     """
 
-    if gnu_make_enabled():
-        return ["--jobserver-fds=%d,%d" % JobServer._job_pipe, "-j"]
+    if JobServer._gnu_make_enabled:
+        return JobServer._gnu_make.make_args(JobServer._job_pipe)
     else:
         return []
 


### PR DESCRIPTION
--jobserver-fds has been renamed to --jobserver-auth.

Also calling make with both --jobserver-auth and -j leads to 'warning:
-jN forced in submake: disabling jobserver mode.'

See https://lists.gnu.org/archive/html/info-gnu/2016-05/msg00013.html