### PR TITLE
Fixed '_catkin_get_enclosing_package:14: command not found: xmllint'

### DIFF
--- a/completion/_catkin
+++ b/completion/_catkin
@@ -85,7 +85,7 @@ _catkin_get_enclosing_package() {
     if [[ -e "$path/package.xml" ]]; then
       _debug_log "Found package root $path"
       # Get the package name
-      _enclosing_package="$(xmllint --xpath '/package/name/text()' '$path/package.xml')"
+      _enclosing_package="$(/usr/bin/xmllint --xpath /package/name/text() $path/package.xml)"
       return 0
     else
       path="$(/bin/readlink -f $path/..)"


### PR DESCRIPTION
Occurred when doing auto-complete at 'catkin build --work[TAB]'. Fixing
the xmllint path led to 'warning: failed to load external entity
"$path/package.xml"'

Don't know enough about these zsh completion scripts to understand why we need absolute paths but "/bin/readlink" was already there.

Also I don't like removing the quotes around the $path variable because it might contain spaces, but again, `"$(/bin/readlink -f $path/..)"` did it first.