### PR TITLE
Fixed various bugs in zsh completion

### DIFF
--- a/completion/_catkin
+++ b/completion/_catkin
@@ -63,7 +63,7 @@ _catkin_get_enclosing_workspace() {
       _workspace_root=$_path
       return 0
     else
-      _path=$(readlink -f $_path/..)
+      _path=$(readlink -f "$_path/..")
     fi
   done
 
@@ -88,7 +88,7 @@ _catkin_get_enclosing_package() {
       _enclosing_package=$(xmllint --xpath "/package/name/text()" "$_path/package.xml")
       return 0
     else
-      _path=$(readlink -f $_path/..)
+      _path=$(readlink -f "$_path/..")
     fi
   done
 
@@ -128,7 +128,7 @@ _catkin_get_packages() {
   local cache_file_path
 
   # Get the workspace root
-  _catkin_get_enclosing_workspace $_workspace_root_hint
+  _catkin_get_enclosing_workspace "$_workspace_root_hint"
 
 
   if [[ "$?" -ne 0 ]]; then

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -202,10 +202,10 @@ _catkin_build_complete() {
   _catkin_get_enclosing_package "$PWD"
 
   if [[ -n $_enclosing_package ]]; then
-    _debug_log "In package $this_package"
+    _debug_log "In package $_enclosing_package"
     build_opts=(\
-      "(--unbuilt)--this[Build '$this_package']"\
-      "(--start-with)--start--with--this[Skip all packages on which `$this_package` depends]"\
+      "(--unbuilt)--this[Build '$_enclosing_package']"\
+      "(--start-with)--start--with--this[Skip all packages on which `$_enclosing_package` depends]"\
       )
   else
     _debug_log "Not in a package"
@@ -241,7 +241,7 @@ _catkin_clean_complete() {
   _catkin_get_enclosing_package "$PWD"
 
   if [[ -n $_enclosing_package ]]; then
-    _debug_log "In package $this_package"
+    _debug_log "In package $_enclosing_package"
     clean_opts=()
   else
     _debug_log "Not in a package"

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -63,7 +63,7 @@ _catkin_get_enclosing_workspace() {
       _workspace_root=$_path
       return 0
     else
-      _path=$(/bin/readlink -f $_path/..)
+      _path=$(readlink -f $_path/..)
     fi
   done
 
@@ -88,7 +88,7 @@ _catkin_get_enclosing_package() {
       _enclosing_package=$(xmllint --xpath "/package/name/text()" "$_path/package.xml")
       return 0
     else
-      _path=$(/bin/readlink -f $_path/..)
+      _path=$(readlink -f $_path/..)
     fi
   done
 

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -205,7 +205,7 @@ _catkin_build_complete() {
     _debug_log "In package $_enclosing_package"
     build_opts=(\
       "(--unbuilt)--this[Build '$_enclosing_package']"\
-      "(--start-with)--start--with--this[Skip all packages on which `$_enclosing_package` depends]"\
+      "(--start-with)--start--with--this[Skip all packages on which '$_enclosing_package' depends]"\
       )
   else
     _debug_log "Not in a package"

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -149,9 +149,8 @@ _catkin_get_packages() {
     zstyle ":completion:${curcontext}:" cache-policy _catkin_packages_caching_policy
   fi
 
-  # If cache is invalid or if the package list is not set yet and can't be retrieved from cache regenerate cache
-  # ( Remember that _retrieve_cache returns 0 if everything's fine, 1 if not. _cache_invalid returns 0 if cache needs rebuilding, 1 otherwise)
-  if _cache_invalid workspace_packages || ( [[ ${+_workspace_packages} -eq 0 ]] && ! _retrieve_cache workspace_packages ); then
+  if ( [[ ${+_workspace_packages} -eq 0 ]] || _cache_invalid workspace_packages ) \
+      && ! _retrieve_cache workspace_packages; then
     _debug_log "Regenerating package cache..."
     _workspace_packages=(${${(f)"$(catkin list -u --quiet)"}})
     _store_cache workspace_packages _workspace_packages

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -85,7 +85,7 @@ _catkin_get_enclosing_package() {
     if [[ -e "$_path/package.xml" ]]; then
       _debug_log "Found package root $_path"
       # Get the package name
-      _enclosing_package=$(xmllint --xpath '/package/name/text()' '$_path/package.xml')
+      _enclosing_package=$(xmllint --xpath "/package/name/text()" "$_path/package.xml")
       return 0
     else
       _path=$(/bin/readlink -f $_path/..)

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -52,18 +52,18 @@ _catkin_get_enclosing_workspace() {
     return 0
   fi
 
-  local path
-  path="$1"
+  local _path
+  _path="$1"
 
-  while [[ "$path" != "/" ]]; do
-    _debug_log "Checking $path/.catkin_tools"
+  while [[ "$_path" != "/" ]]; do
+    _debug_log "Checking $_path/.catkin_tools"
 
-    if [[ -e "$path/.catkin_tools" ]]; then
-      _debug_log "Found workspace root $path"
-      _workspace_root=$path
+    if [[ -e "$_path/.catkin_tools" ]]; then
+      _debug_log "Found workspace root $_path"
+      _workspace_root=$_path
       return 0
     else
-      path="$(/bin/readlink -f $path/..)"
+      _path=$(/bin/readlink -f $_path/..)
     fi
   done
 
@@ -76,19 +76,19 @@ _catkin_get_enclosing_package() {
     return 0
   fi
 
-  local path
-  path="$1"
+  local _path
+  _path="$1"
 
-  while [[ "$path" != "/" ]]; do
-    _debug_log "Checking $path/package.xml"
+  while [[ "$_path" != "/" ]]; do
+    _debug_log "Checking $_path/package.xml"
 
-    if [[ -e "$path/package.xml" ]]; then
-      _debug_log "Found package root $path"
+    if [[ -e "$_path/package.xml" ]]; then
+      _debug_log "Found package root $_path"
       # Get the package name
-      _enclosing_package="$(xmllint --xpath '/package/name/text()' '$path/package.xml')"
+      _enclosing_package=$(xmllint --xpath '/package/name/text()' '$_path/package.xml')
       return 0
     else
-      path="$(/bin/readlink -f $path/..)"
+      _path=$(/bin/readlink -f $_path/..)
     fi
   done
 


### PR DESCRIPTION
These are actual bugs:
- Fixed $path overwriting $PATH
- Fixed $_path not being expanded in single quotes
- Fixed usage of undefined variable $this_package
- Fixed `` being interpreted as command execution

The following are just "sanitization":
- Replaced '/bin/readlink' call with just 'readlink'
- Added quotes to allow paths containing blanks