### PR TITLE
Fixed 'pip install --user catkin_tools'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,8 @@ To enable tab completion, add the following to your '~/.bashrc':
                         'catkin_tools-completion.bash')))
 
 parser = argparse.ArgumentParser(add_help=False)
-prefix_group = parser.add_mutually_exclusive_group()
-prefix_group.add_argument('--user', '--home', action='store_true')
-prefix_group.add_argument('--prefix', default=None)
+parser.add_argument('--user', '--home', action='store_true')
+parser.add_argument('--prefix', default=None)
 
 opts, _ = parser.parse_known_args(sys.argv)
 userbase = site.getuserbase() if opts.user else None


### PR DESCRIPTION
pip passes `--user --prefix=` when the user calls `pip install --user`,
which conflicted with the mutually_exclusive_group being used to parse
these arguments.

The mutually_exclusive_group is not necessary since pip prevents the
user from passing `--user` together with `--prefix` anyhow. By not
checking it here again, we can accept pip passing `--user --prefix=` to
us.

---
Example:
```
$ cd catkin_tools
$ pip2 install --user .
[...]
  Running setup.py install for catkin-tools ... error
    Complete output from command /usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-NhWIKe-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-fwXLCn-record/install-record.txt --single-version-externally-managed --compile --user --prefix=:
    usage: -c [--user | --prefix PREFIX]
    -c: error: argument --prefix: not allowed with argument --user/--home
    
    ----------------------------------------
Command "/usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-NhWIKe-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-fwXLCn-record/install-record.txt --single-version-externally-managed --compile --user --prefix=" failed with error code 2 in /tmp/pip-NhWIKe-build/
```

The pip code that causes this:
https://github.com/pypa/pip/blob/ff5b2013a0a9001a457034481ed918e1a3fea7ef/src/pip/_internal/commands/install.py#L195-L207