### PR TITLE
Sort authors/maintainers for correct email assignment

### DIFF
--- a/catkin_tools/verbs/catkin_create/cli.py
+++ b/catkin_tools/verbs/catkin_create/cli.py
@@ -117,6 +117,15 @@ def main(opts):
     try:
         # Get absolute path to directory containing package
         package_dest_path = os.path.abspath(opts.path)
+
+        # Sort list of maintainers and authors (it will also be sorted inside
+        # PackageTemplate so by sorting it here, we ensure that the same order
+        # is used.  This is important later when email addresses are assigned.
+        if opts.maintainers:
+            opts.maintainers.sort(key=lambda x: x[0])
+        if opts.authors:
+            opts.authors.sort(key=lambda x: x[0])
+
         for package_name in opts.name:
             print('Creating package "%s" in "%s"...' % (package_name, package_dest_path))
             target_path = os.path.join(package_dest_path, package_name)


### PR DESCRIPTION
The `PackageTemplate` class internally sorts the authors and maintainers by their names.  To ensure that email addresses are later assigned to the correct names, also sort them in the main function.

This fixes #486.

The result can be seen with the following command:

    catkin create pkg foobar --maintainer Bob bob@mail.com --maintainer Alice alice1@mail.com --maintainer Alice alice2@mail.com --author Bob bob@mail.com --author Alice alice1@mail.com --author Alice alice2@mail.com
    cat foobar/package.xml

**Without this fix:**
```
  ...
  <maintainer email="bob@mail.com">Alice</maintainer>
  <maintainer email="alice1@mail.com">Alice</maintainer>
  <maintainer email="alice2@mail.com">Bob</maintainer>

  ...

  <author email="bob@mail.com">Alice</author>
  <author email="alice1@mail.com">Alice</author>
  <author email="alice2@mail.com">Bob</author>
  ...
```

**With this fix:**
```
  ...
  <maintainer email="alice1@mail.com">Alice</maintainer>
  <maintainer email="alice2@mail.com">Alice</maintainer>
  <maintainer email="bob@mail.com">Bob</maintainer>

  ...

  <author email="alice1@mail.com">Alice</author>
  <author email="alice2@mail.com">Alice</author>
  <author email="bob@mail.com">Bob</author>
  ...
```