### PR TITLE
Respect VERBOSE environment variable if already set before in verbose mode

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -398,7 +398,7 @@ def main(opts):
         parallel_jobs = None
 
     # Set VERBOSE environment variable
-    if opts.verbose:
+    if opts.verbose and not 'VERBOSE' in os.environ:
         os.environ['VERBOSE'] = '1'
 
     try:


### PR DESCRIPTION
At the moment it is not possible to build a workspace with catkin_tools in verbose mode without also switching `make` to verbose mode.

For our continuous integration jobs I would like to have a way to see the normal output of cmake and make (with `catkin build -v`), but without all the clutter produced by `make` if the `VERBOSE` environment variable is set. The alternative is `-i`, but it does not behave well if the output is not a terminal and if multiple packages are built in parallel.

Note that setting `VERBOSE=0` does not have the desired effect. The variable needs to be defined, but empty to disable make's verbosity (`VERBOSE= catkin build -v ...`).

Maybe the whole section was a leftover from debugging catkin_tools? The [GitHub issue template](https://github.com/catkin/catkin_tools/blob/master/.github/ISSUE_TEMPLATE.md) explicitly asks to set VERBOSE=1 although `-v` already implies that in the current version:
```
[//]: # (Use `VERBOSE=1 catkin build -p1 -v` for verbose output)
```