### PR TITLE
When using a non-standard shell fix the usage of DEFAULT_SHELL.

### DIFF
--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -110,7 +110,8 @@ def get_resultspace_environment(result_space_path, base_env=None, quiet=False, c
 
     # Use fallback shell if using a non-standard shell
     if shell_name not in ['bash', 'zsh']:
-        shell_name = 'bash'
+        shell_path = DEFAULT_SHELL
+        (_, shell_name) = os.path.split(shell_path)
 
     # Check to make sure result_space_path contains the appropriate setup file
     setup_file_path = os.path.join(result_space_path, 'env.sh')


### PR DESCRIPTION
Previously, using a non-standard shell meant using that non-standard shell's path (shell_path) whereas the shell_name would be bash. Not only is there this discrepancy, but then the command is actually run with the non-standard shell, which is liable to cause runtime errors (as it does if e.g. SHELL=/usr/bin/fish).