### PR TITLE
Fix bug when workspace contains special characters

### DIFF
--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -21,7 +21,7 @@ from catkin_tools.argument_parsing import add_context_args
 
 from catkin_tools.context import Context
 
-from catkin_tools.terminal_color import ColorMapper
+from catkin_tools.terminal_color import ColorMapper, sanitize
 
 color_mapper = ColorMapper()
 clr = color_mapper.clr
@@ -141,7 +141,7 @@ def main(opts):
         summary_notes = []
 
         if not context.initialized() and do_init:
-            summary_notes.append(clr('@!@{cf}Initialized new catkin workspace in `%s`@|' % context.workspace))
+            summary_notes.append(clr('@!@{cf}Initialized new catkin workspace in `%s`@|' % sanitize(context.workspace)))
 
         if context.initialized() or do_init:
             Context.save(context)


### PR DESCRIPTION
Simply sanitize the workspace name when printing it out

Would fix #521 