### PR TITLE
add local_setup.* to DEVEL_LINK_BLACKLIST

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -639,6 +639,9 @@ DEVEL_LINK_BLACKLIST = DEVEL_LINK_PREBUILD_BLACKLIST + [
     'setup.bash',
     'setup.zsh',
     'setup.sh',
+    'local_setup.bash',
+    'local_setup.zsh',
+    'local_setup.sh',
     '_setup_util.py',
 ]
 


### PR DESCRIPTION
Attempt to resolve #538, adding `local_setup.*` to `DEVEL_LINK_BLACKLIST` as suggested in https://github.com/catkin/catkin_tools/issues/538#issuecomment-470315837.
This resolves the warnings but also doesn't install `local_setup.*` shell files.
As I don't know the purpose of adding those files to catkin, I cannot judge whether this is fine or not.