### PR TITLE
Fix travis failures on Ubuntu

### DIFF
--- a/.travis.before_install.bash
+++ b/.travis.before_install.bash
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  sudo apt-get install enchant -y
+  echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs) main universe restricted" > /etc/apt/sources.list
+  echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-updates main universe restricted" >> /etc/apt/sources.list
+  sudo apt update
+  sudo apt install enchant -y
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
   if [ "$PYTHON" == "/usr/local/bin/python3" ]; then
     # Brewed Python 3.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ matrix:
       python: "3.4"
       os: linux
       env: PYTHON=/usr/bin/python3.4 CATKIN_VERSION=indigo-devel
-    - os: osx
-      python: 2
-      env: PYTHON=/usr/local/bin/python2 CATKIN_VERSION=indigo-devel
-    - os: osx
-      python: 3
-      env: PYTHON=/usr/local/bin/python3 CATKIN_VERSION=indigo-devel
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@
 language: generic
 matrix:
   include:
-    - dist: trusty
-      python: 2.7
+    - dist: xenial
       language: python
       python: "2.7"
       os: linux
       env: PYTHON=/usr/bin/python2.7 CATKIN_VERSION=indigo-devel
-    - dist: trusty
-      python: 3.4
+    - dist: xenial
       language: python
       python: "3.4"
       os: linux

--- a/catkin_tools/execution/io.py
+++ b/catkin_tools/execution/io.py
@@ -109,21 +109,23 @@ class IOBufferContainer(object):
     def get_interleaved_log(self):
         """get decoded interleaved log."""
         try:
-          return self._decode(self.interleaved_buffer)
-        except:
-          return "interleaved_log: some output cannot be displayed.\n"
+            return self._decode(self.interleaved_buffer)
+        except UnicodeDecodeError:
+            return "interleaved_log: some output cannot be displayed.\n"
+
     def get_stdout_log(self):
         """get decoded stdout log."""
         try:
-          return self._decode(self.stdout_buffer)
-        except:
-          return "stdout_log: some output cannot be displayed.\n"
+            return self._decode(self.stdout_buffer)
+        except UnicodeDecodeError:
+            return "stdout_log: some output cannot be displayed.\n"
+
     def get_stderr_log(self):
         """get decoded stderr log."""
         try:
-          return self._decode(self.stderr_buffer)
-        except:
-          return "stderr_log: some output cannot be displayed.\n"
+            return self._decode(self.stderr_buffer)
+        except UnicodeDecodeError:
+            return "stderr_log: some output cannot be displayed.\n"
 
     def _encode(self, data):
         """Encode a Python str into bytes.

--- a/catkin_tools/execution/job_server.py
+++ b/catkin_tools/execution/job_server.py
@@ -152,8 +152,8 @@ class JobServer(object):
         elif type(max_mem) is float or type(max_mem) is int:
             mem_percent = max_mem
         elif type(max_mem) is str:
-            m_percent = re.search('([0-9]+)\%', max_mem)
-            m_abs = re.search('([0-9]+)([kKmMgG]{0,1})', max_mem)
+            m_percent = re.search(r'([0-9]+)\%', max_mem)
+            m_abs = re.search(r'([0-9]+)([kKmMgG]{0,1})', max_mem)
 
             if m_percent is None and m_abs is None:
                 cls._max_mem = None

--- a/catkin_tools/jobs/commands/cmake.py
+++ b/catkin_tools/jobs/commands/cmake.py
@@ -67,14 +67,14 @@ class CMakeIOBufferProtocol(IOBufferProtocol):
         #  - output formatting line (subs captured groups)
         #  - functor which filters captured groups
         filters = [
-            ('^-- :(.+)', '@{cf}--@| :@{yf}{}@|', None),
-            ('^-- (.+)', '@{cf}--@| {}', None),
-            ('CMake Error at (.+):(.+)', '@{rf}@!CMake Error@| at {}:{}', self.abspath),
-            ('CMake Warning at (.+):(.+)', '@{yf}@!CMake Warning@| at {}:{}', self.abspath),
-            ('CMake Warning (dev) at (.+):(.+)', '@{yf}@!CMake Warning (dev)@| at {}:{}', self.abspath),
-            ('(?i)(warning.*)', '@(yf){}@|', None),
-            ('(?i)ERROR:(.*)', '@!@(rf)ERROR:@|{}@|', None),
-            ('Call Stack \(most recent call first\):(.*)', '@{cf}Call Stack (most recent call first):@|{}', None),
+            (r'^-- :(.+)', '@{cf}--@| :@{yf}{}@|', None),
+            (r'^-- (.+)', '@{cf}--@| {}', None),
+            (r'CMake Error at (.+):(.+)', '@{rf}@!CMake Error@| at {}:{}', self.abspath),
+            (r'CMake Warning at (.+):(.+)', '@{yf}@!CMake Warning@| at {}:{}', self.abspath),
+            (r'CMake Warning (dev) at (.+):(.+)', '@{yf}@!CMake Warning (dev)@| at {}:{}', self.abspath),
+            (r'(?i)(warning.*)', '@(yf){}@|', None),
+            (r'(?i)ERROR:(.*)', '@!@(rf)ERROR:@|{}@|', None),
+            (r'Call Stack \(most recent call first\):(.*)', '@{cf}Call Stack (most recent call first):@|{}', None),
         ]
 
         self.filters = [(re.compile(p), r, f) for (p, r, f) in filters]
@@ -165,7 +165,7 @@ class CMakeMakeIOBufferProtocol(IOBufferProtocol):
         super(CMakeMakeIOBufferProtocol, self).on_stdout_received(data)
 
         # Parse CMake Make completion progress
-        progress_matches = re.match('\[\s*([0-9]+)%\]', self._decode(data))
+        progress_matches = re.match(r'\[\s*([0-9]+)%\]', self._decode(data))
         if progress_matches is not None:
             self.event_queue.put(ExecutionEvent(
                 'STAGE_PROGRESS',


### PR DESCRIPTION
Travis was failing on Ubuntu on account of not being able to install the `enchant` package. Seems the base images were configured with apt having only `${dist}-security` plus a ton of PPAs, and no default repos. This is baffling to me, but also easy to correct at build time.

I've also moved the builds from Trusty to Xenial, given that Trusty is EOL next month anyway.