### PR TITLE
Use yaml.safe_load everywhere.

### DIFF
--- a/catkin_tools/config.py
+++ b/catkin_tools/config.py
@@ -91,7 +91,7 @@ def get_verb_aliases(path=catkin_config_path):
         if file_name.endswith('.yaml'):
             full_path = os.path.join(verb_aliases_path, file_name)
             with open(full_path, 'r') as f:
-                yaml_dict = yaml.load(f)
+                yaml_dict = yaml.safe_load(f)
             if yaml_dict is None:
                 continue
             if not isinstance(yaml_dict, dict):

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -367,7 +367,7 @@ def get_profiles_data(workspace_path):
         profiles_yaml_file_path = os.path.join(profiles_path, PROFILES_YML_FILE_NAME)
         if os.path.exists(profiles_yaml_file_path):
             with open(profiles_yaml_file_path, 'r') as profiles_file:
-                return yaml.load(profiles_file)
+                return yaml.safe_load(profiles_file)
 
     return {}
 
@@ -395,7 +395,7 @@ def get_metadata(workspace_path, profile, verb):
         return dict()
 
     with open(metadata_file_path, 'r') as metadata_file:
-        return yaml.load(metadata_file)
+        return yaml.safe_load(metadata_file)
 
 
 def update_metadata(workspace_path, profile, verb, new_data={}, no_init=False, merge=True):

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -240,7 +240,7 @@ def build_isolated_workspace(
     # Check build config
     if os.path.exists(os.path.join(context.build_space_abs, BUILDSPACE_MARKER_FILE)):
         with open(os.path.join(context.build_space_abs, BUILDSPACE_MARKER_FILE)) as buildspace_marker_file:
-            existing_buildspace_marker_data = yaml.load(buildspace_marker_file)
+            existing_buildspace_marker_data = yaml.safe_load(buildspace_marker_file)
             misconfig_lines = ''
             for (k, v) in existing_buildspace_marker_data.items():
                 new_v = buildspace_marker_data.get(k, None)


### PR DESCRIPTION
Fixes the warnings noted in https://github.com/catkin/catkin_tools/pull/541#issuecomment-476703539. On invocation, `catkin` shows:

```
~/catkin_tools/catkin_tools/config.py:94: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  yaml_dict = yaml.load(f)
~/catkin_tools/catkin_tools/metadata.py:398: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(metadata_file)
~/catkin_tools/catkin_tools/verbs/catkin_build/build.py:243: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  existing_buildspace_marker_data = yaml.load(buildspace_marker_file)
```