### PR TITLE
add authors/maintainers/licenses to context, which are the default values on package creation

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -66,6 +66,9 @@ class Context(object):
         'catkin_make_args',
         'whitelist',
         'blacklist',
+        'authors',
+        'maintainers',
+        'licenses',
     ]
 
     EXTRA_KEYS = [
@@ -247,6 +250,9 @@ class Context(object):
         space_suffix=None,
         whitelist=None,
         blacklist=None,
+        authors=None,
+        maintainers=None,
+        licenses=None,
         **kwargs
     ):
         """Creates a new Context object, optionally initializing with parameters
@@ -292,6 +298,12 @@ class Context(object):
         :param blacklist: a list of packages to ignore by default
         :type blacklist: list
         :raises: ValueError if workspace or source space does not exist
+        :type authors: list
+        :param authors: a list of default authors
+        :type maintainers: list
+        :param maintainers: a list of default maintainers
+        :type licenses: list
+        :param licenses: a list of default licenses
         """
         self.__locked = False
 
@@ -319,6 +331,11 @@ class Context(object):
         # Handle package whitelist/blacklist
         self.whitelist = whitelist or []
         self.blacklist = blacklist or []
+
+        # Handle default authors/maintainers
+        self.authors = authors or []
+        self.maintainers = maintainers or []
+        self.licenses = licenses or 'TODO'
 
         # Handle build options
         self.devel_layout = devel_layout if devel_layout else 'linked'
@@ -729,6 +746,30 @@ class Context(object):
     @blacklist.setter
     def blacklist(self, value):
         self.__blacklist = value
+
+    @property
+    def authors(self):
+        return self.__authors
+
+    @authors.setter
+    def authors(self, value):
+        self.__authors = value
+
+    @property
+    def maintainers(self):
+        return self.__maintainers
+
+    @maintainers.setter
+    def maintainers(self, value):
+        self.__maintainers = value
+
+    @property
+    def licenses(self):
+        return self.__licenses
+
+    @licenses.setter
+    def licenses(self, value):
+        self.__licenses = value
 
     @property
     def private_devel_path(self):

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -58,6 +58,17 @@ def prepare_arguments(parser):
     add('--mkdirs', action='store_true', default=False,
         help='Create directories required by the configuration (e.g. source space) if they do not already exist.')
 
+    create_group = parser.add_argument_group(
+        'Package Create Defaults', 'Information of default authors/maintainers of created packages')
+    add = create_group.add_mutually_exclusive_group().add_argument
+    add('--authors', metavar=('NAME', 'EMAIL'), dest='authors', nargs='+', required=False, type=str, default=None,
+        help='Set the default authors of created packages')
+    add('--maintainers', metavar=('NAME', 'EMAIL'), dest='maintainers', nargs='+',
+        required=False, type=str, default=None,
+        help='Set the default maintainers of created packages')
+    add('--licenses', metavar=('LICENSE'), dest='licenses', nargs='+', required=False, type=str, default=None,
+        help='Set the default licenses of created packages')
+
     lists_group = parser.add_argument_group(
         'Package Build Defaults', 'Packages to include or exclude from default build behavior.')
     add = lists_group.add_mutually_exclusive_group().add_argument

--- a/catkin_tools/verbs/catkin_create/cli.py
+++ b/catkin_tools/verbs/catkin_create/cli.py
@@ -16,6 +16,8 @@ from __future__ import print_function
 
 import os
 
+from catkin_tools.argument_parsing import add_context_args
+from catkin_tools.context import Context
 from catkin_pkg.package_templates import create_package_files, PackageTemplate
 
 # Exempt build directories
@@ -24,7 +26,7 @@ from catkin_pkg.package_templates import create_package_files, PackageTemplate
 
 def prepare_arguments(parser):
     # Workspace / profile args
-    # add_context_args(parser)
+    add_context_args(parser)
 
     subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
 
@@ -114,6 +116,8 @@ def prepare_arguments(parser):
 
 def main(opts):
 
+    # Load the context
+    ctx = Context.load(opts.workspace, opts.profile, opts, append=True)
     try:
         # Get absolute path to directory containing package
         package_dest_path = os.path.abspath(opts.path)
@@ -121,10 +125,26 @@ def main(opts):
         # Sort list of maintainers and authors (it will also be sorted inside
         # PackageTemplate so by sorting it here, we ensure that the same order
         # is used.  This is important later when email addresses are assigned.
+        if not opts.maintainers:
+            maintainers = []
+            for x in ctx.maintainers:
+                email = x.split()[-1]
+                name = ' '.join(x.split()[:-1])
+                maintainers += [[name, email]]
+            opts.maintainers = maintainers
         if opts.maintainers:
             opts.maintainers.sort(key=lambda x: x[0])
+        if not opts.authors:
+            authors = []
+            for x in ctx.authors:
+                email = x.split()[-1]
+                name = ' '.join(x.split()[:-1])
+                authors += [[name, email]]
+            opts.authors = authors
         if opts.authors:
             opts.authors.sort(key=lambda x: x[0])
+        if not opts.license:
+            opts.license = ctx.licenses or []
 
         for package_name in opts.name:
             print('Creating package "%s" in "%s"...' % (package_name, package_dest_path))
@@ -132,7 +152,7 @@ def main(opts):
             package_template = PackageTemplate._create_package_template(
                 package_name=package_name,
                 description=opts.description,
-                licenses=opts.license or [],
+                licenses=opts.license,
                 maintainer_names=[m[0] for m in opts.maintainers] if opts.maintainers else [],
                 author_names=[a[0] for a in opts.authors] if opts.authors else [],
                 version=opts.version,


### PR DESCRIPTION
This PR adds `--authors`, `--maintainers` and `--licenses` options to set the default values on creating new packages.

By using this PR, we can use short command line arguments to create new packages:

BEFORE:

`catkin create pkg awesome_pkg -a 'John Doe' 'foo@bar.com' -a ... -m 'John Doe' 'foo@bar.com' -m ... -l MIT -c <deps>`

AFTER:

`catkin create pkg awesome_pkg -c <deps>`