### PR TITLE
Fix space-suffix option

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -306,9 +306,10 @@ class Context(object):
         for space, space_dict in Context.SPACES.items():
             key_name = space + '_space'
             default = space_dict['default']
-            if space_suffix and space != 'source':
-                default += space_suffix
-            setattr(self, key_name, kwargs.pop(key_name, default))
+            value = kwargs.pop(key_name, default)
+            if value == default and space_suffix and space != 'source':
+                value += space_suffix
+            setattr(self, key_name, value)
 
         # Check for unhandled context options
         if len(kwargs) > 0:


### PR DESCRIPTION
Addresses https://github.com/catkin/catkin_tools/issues/545

From the docs, the `catkin config --space-suffix` argument should set the "Suffix for build, devel, and install space if they are not otherwise explicitly set." However, currently, the default values for each of these spaces are considered "explicitly set". This means that, except for an extremely narrow window when first initializing a workspace, the `--space-suffix` argument is always useless.

This PR allows `--space-suffix` to affect spaces whose values are either not set **or are set to the default values**. This brings the tool back in line with how it used to behave.

------
Aside: The documentation says that this affects the build, devel, and install spaces, but the code is implemented such that it affects the build, devel, install, and log spaces. I assume the code is correct and the documentation is out of date, but I'd like to get confirmation on which is prefered so that I can update the code/documentation accordingly.