### PR TITLE
Force sphinxcontrib-spelling < 4.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash
-  - pip install setuptools argparse catkin-pkg PyYAML psutil trollius osrf_pycommon pyenchant sphinxcontrib-spelling
+  - pip install setuptools argparse catkin-pkg PyYAML psutil trollius osrf_pycommon pyenchant "sphinxcontrib-spelling<4.3.0"
 install:
   # Install catkin_tools
   - python setup.py develop


### PR DESCRIPTION
Addresses #559.

`sphinxcontrib-spelling` 4.3.0 requires at least `sphinx` 2.0.0, which in turn requires at least Py3.5. Both Py2.7 and 3.4 are no longer supported as of `sphinx` 2.0.0, which causes the Travis build to fail during before_install.