### PR TITLE
Fix permissions of created setup files

### DIFF
--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -149,9 +149,14 @@ def generate_env_file(logger, event_queue, context, install_target):
     os.write(tmp_dst_handle, data.encode('utf-8'))
     os.close(tmp_dst_handle)
 
+    # Make the file executable without overwriting the permissions for
+    # the group and others (copy r flags to x)
+    mode = os.stat(tmp_dst_path).st_mode
+    mode |= (mode & 0o444) >> 2
+    os.chmod(tmp_dst_path, mode)
+
     # Do an atomic rename with os.rename
     os.rename(tmp_dst_path, env_file_path)
-    os.chmod(env_file_path, 0o755)
 
     return 0
 

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -16,7 +16,6 @@
 
 import os
 import pkg_resources
-import stat
 import sys
 import time
 import traceback
@@ -632,19 +631,16 @@ def _create_unmerged_devel_setup(context, unbuilt):
     )
     with open(setup_sh_path, 'w') as f:
         f.write(env_file)
-    os.chmod(setup_sh_path, stat.S_IXUSR | stat.S_IWUSR | stat.S_IRUSR)
 
     # Create setup.bash file
     setup_bash_path = os.path.join(context.devel_space_abs, 'setup.bash')
     with open(setup_bash_path, 'w') as f:
         f.write(SETUP_BASH_TEMPLATE)
-    os.chmod(setup_bash_path, stat.S_IXUSR | stat.S_IWUSR | stat.S_IRUSR)
 
     # Create setup.zsh file
     setup_zsh_path = os.path.join(context.devel_space_abs, 'setup.zsh')
     with open(setup_zsh_path, 'w') as f:
         f.write(SETUP_ZSH_TEMPLATE)
-    os.chmod(setup_zsh_path, stat.S_IXUSR | stat.S_IWUSR | stat.S_IRUSR)
 
 
 def _create_unmerged_devel_setup_for_install(context):


### PR DESCRIPTION
`catkin_tools` should respect the default permissions assigned by the OS to new files, similar to `chmod +X <file>` at the command line.

The default permissions can be influenced by the active [umask](https://en.wikipedia.org/wiki/Umask). For example, on a shared file system (network mount or a workspace mounted in a docker container) the group of the user should have write access, too (by setting the umask to `0002` or `0000` instead of the default `0022`). Because each build command tries to overwrite the setup files, building the same workspace as a different user fails because of permission errors.

The `setup.*` files created by `build.py` for an isolated devel-space do not need to be executable. The default permissions should be fine, no?

[catkin](https://github.com/ros/catkin) also creates its setup and other files by forcefully overwriting the permissions. I will open another PR there.