### PR TITLE
Update release suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: trusty vivid wily xenial wheezy yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: trusty vivid wily xenial wheezy yakkety zesty artful bionic jessie stretch buster
+Suite: trusty vivid wily xenial wheezy yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,4 +4,4 @@ Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-X-Python3-Version: >= 3.2
+X-Python3-Version: >= 3.5


### PR DESCRIPTION
Cosmic, Disco, and Eoan are now live on the ROS bootstrap repository and future releases should be pushed to them as well.

The second commit removes suites older than Ubuntu Xenial and Debian Jessie.