### PR TITLE
Allow to switch profiles even if the current profile is misconfigured

### DIFF
--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -113,7 +113,7 @@ def list_profiles(profiles, active_profile, unformatted=False, active=False):
 def main(opts):
     try:
         # Load a context with initialization
-        ctx = Context.load(opts.workspace)
+        ctx = Context.load(opts.workspace, load_env=False)
 
         if not ctx.initialized():
             print("A catkin workspace must be initialized before profiles can be managed.")


### PR DESCRIPTION
This PR follows #406 

**Current behavior:**
If the current profile is misconfigured, we cannot switch to any profile.

**After the PR:**
If the current profile is misconfigured, we **can** switch to any profile.

I do not know if there are adverse problems due to not loading the environment but that makes sense for the `profile` verb not to crash due to profile problems.