### PR TITLE
Handle empty file in `get_metadata` correctly

### DIFF
--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -391,7 +391,7 @@ def get_metadata(workspace_path, profile, verb):
 
     (metadata_path, metadata_file_path) = get_paths(workspace_path, profile, verb)
 
-    if not os.path.exists(metadata_file_path):
+    if not os.path.exists(metadata_file_path) or os.path.getsize(metadata_file_path) == 0:
         return dict()
 
     with open(metadata_file_path, 'r') as metadata_file:


### PR DESCRIPTION
If the `metadata_file_path` exists but the `metadata_file` is empty, `yaml.safe_load(metadata_file)` will return None. But the caller expects a dictionary which can lead to a crash. (e.g. in https://github.com/catkin/catkin_tools/blob/master/catkin_tools/verbs/catkin_build/cli.py#L371)

I'm not sure how I ended up with this file being empty (I can't remember touching it)...