### PR TITLE
Replace trollius by asyncio

### DIFF
--- a/.travis.before_install.bash
+++ b/.travis.before_install.bash
@@ -6,13 +6,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   sudo apt update
   sudo apt install enchant -y
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  if [ "$PYTHON" == "/usr/local/bin/python3" ]; then
-    # Brewed Python 3.
-    brew upgrade python
-  elif [ "$PYTHON" == "/usr/local/bin/python2" ]; then
-    # Brewed Python 2.
-    brew install python@2
-  fi
+  brew upgrade python
   $PYTHON -m pip install virtualenv
   $PYTHON -m virtualenv -p $PYTHON venv
   brew install enchant

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,13 @@ matrix:
   include:
     - dist: xenial
       language: python
-      python: "2.7"
-      os: linux
-      env: PYTHON=/usr/bin/python2.7 CATKIN_VERSION=indigo-devel
-    - dist: xenial
-      language: python
       python: "3.4"
       os: linux
       env: PYTHON=/usr/bin/python3.4 CATKIN_VERSION=indigo-devel
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash
-  - pip install setuptools argparse catkin-pkg PyYAML psutil trollius osrf_pycommon pyenchant "sphinxcontrib-spelling<4.3.0"
+  - pip install setuptools argparse catkin-pkg PyYAML psutil osrf_pycommon pyenchant "sphinxcontrib-spelling<4.3.0"
 install:
   # Install catkin_tools
   - python setup.py develop

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 
-import trollius as asyncio
+import asyncio
 
 from shlex import split as _cmd_split
 try:
@@ -63,7 +63,7 @@ class FakeLock(asyncio.locks.Lock):
 
     @asyncio.coroutine
     def acquire(self):
-        raise asyncio.Return(True)
+        return(True)
 
     def release(self):
         pass

--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -18,7 +18,7 @@ import traceback
 
 from itertools import tee
 
-import trollius as asyncio
+import asyncio
 
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import FIRST_COMPLETED
@@ -70,7 +70,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
         # Check for stage synchronization lock
         if stage.locked_resource is not None:
             lock = locks.setdefault(stage.locked_resource, asyncio.Lock())
-            yield asyncio.From(lock)
+            yield from(lock)
         else:
             lock = FakeLock()
 
@@ -79,7 +79,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
             if stage.occupy_job:
                 if not occupying_job:
                     while job_server.try_acquire() is None:
-                        yield asyncio.From(asyncio.sleep(0.05))
+                        yield from(asyncio.sleep(0.05))
                     occupying_job = True
             else:
                 if occupying_job:
@@ -103,7 +103,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                             # Get the logger
                             protocol_type = stage.logger_factory(verb, job.jid, stage.label, event_queue, log_path)
                             # Start asynchroonous execution
-                            transport, logger = yield asyncio.From(
+                            transport, logger = yield from(
                                 async_execute_process(
                                     protocol_type,
                                     **stage.async_execute_process_kwargs))
@@ -112,7 +112,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                             if 'Text file busy' in str(exc):
                                 # This is a transient error, try again shortly
                                 # TODO: report the file causing the problem (exc.filename)
-                                yield asyncio.From(asyncio.sleep(0.01))
+                                yield from(asyncio.sleep(0.01))
                                 continue
                             raise
 
@@ -125,7 +125,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                         **stage.async_execute_process_kwargs))
 
                     # Asynchronously yield until this command is completed
-                    retcode = yield asyncio.From(logger.complete)
+                    retcode = yield from(logger.complete)
                 except:  # noqa: E722
                     # Bare except is permissable here because the set of errors which the CommandState might raise
                     # is unbounded. We capture the traceback here and save it to the build's log files.
@@ -137,7 +137,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
                 logger = IOBufferLogger(verb, job.jid, stage.label, event_queue, log_path)
                 try:
                     # Asynchronously yield until this function is completed
-                    retcode = yield asyncio.From(get_loop().run_in_executor(
+                    retcode = yield from(get_loop().run_in_executor(
                         threadpool,
                         stage.function,
                         logger,
@@ -179,7 +179,7 @@ def async_job(verb, job, threadpool, locks, event_queue, log_path):
             lock.release()
 
     # Finally, return whether all stages of the job completed
-    raise asyncio.Return(job.jid, all_stages_succeeded)
+    return(job.jid, all_stages_succeeded)
 
 
 @asyncio.coroutine
@@ -272,14 +272,14 @@ def execute_jobs(
         ))
 
         # Process jobs as they complete asynchronously
-        done_job_fs, active_job_fs = yield asyncio.From(asyncio.wait(
+        done_job_fs, active_job_fs = yield from(asyncio.wait(
             active_job_fs,
             timeout=0.10,
             return_when=FIRST_COMPLETED))
 
         for done_job_f in done_job_fs:
             # Capture a result once the job has finished
-            job_id, succeeded = yield asyncio.From(done_job_f)
+            job_id, succeeded = yield from(done_job_f)
 
             # Release a jobserver token now that this job has succeeded
             job_server.release(job_id)
@@ -362,7 +362,7 @@ def execute_jobs(
         completed=completed_jobs
     ))
 
-    raise asyncio.Return(all(completed_jobs.values()))
+    return(all(completed_jobs.values()))
 
 
 def run_until_complete(coroutine):

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -22,7 +22,7 @@ import time
 import traceback
 import yaml
 
-import trollius as asyncio
+import asyncio
 
 try:
     # Python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ osrf_pycommon
 pyyaml
 setuptools
 sphinxcontrib-programoutput
-trollius

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ install_requires = [
     'PyYAML',
     'osrf-pycommon > 0.1.1',
 ]
-if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-    install_requires.append('argparse')
 
 # Figure out the resources that need to be installed
 this_dir = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     'setuptools',
     'PyYAML',
     'osrf-pycommon > 0.1.1',
-    'trollius'
 ]
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     install_requires.append('argparse')

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ All tests can be run from the root of the repository.
 
 First, make sure the required test dependencies are installed:
 
-*Ubuntu* -- `sudo apt-get install cmake libgtest-dev build-essential python-setuptools python-pip`
+*Ubuntu* -- `sudo apt-get install cmake libgtest-dev build-essential python3-setuptools python3-pip`
 
 *OS X* -- `pip install setuptools`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ First, make sure the required test dependencies are installed:
 
 ```
 pip install argparse catkin-pkg distribute PyYAML psutil
-pip install nose coverage flake8 mock trollius empy --upgrade
+pip install nose coverage flake8 mock empy --upgrade
 pip install git+https://github.com/osrf/osrf_pycommon.git
 ```
 


### PR DESCRIPTION
Since trollius is a python2 package that is not necessary for python3 because the functionality has been replaced by the python `asyncio` module, this pull request replaces trollius by asyncio. It closes #520 and would close #558 because the dependency to trollius could be dropped.
To be python3 compatible, #565 should also be merged.

Obviously, this pull request would drop python2 support, which is currently probably not realistic. Would it be possible to merge this to a separate branch to release a different version for python3?