### PR TITLE
Set Travis to check Python 3.5 and 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ matrix:
   include:
     - dist: xenial
       language: python
-      python: "3.4"
+      python: "3.5"
       os: linux
-      env: PYTHON=/usr/bin/python3.4 CATKIN_VERSION=indigo-devel
+      env: PYTHON=/usr/bin/python3.5 CATKIN_VERSION=indigo-devel
+    - dist: bionic
+      language: python
+      python: "3.6"
+      os: linux
+      env: PYTHON=/usr/bin/python3.6 CATKIN_VERSION=indigo-devel
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ else:
 setup(
     name='catkin_tools',
     version='0.4.5',
+    python_requires='>=3.5',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={
         'catkin_tools': [


### PR DESCRIPTION
Small follow-on to #574, adding the `python_requires` attribute in `setup.py` to prevent accidental installation into a Python 2 virtualenv.