### PR TITLE
Revert #561

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash
-  - pip install setuptools argparse catkin-pkg PyYAML psutil osrf_pycommon pyenchant "sphinxcontrib-spelling<4.3.0"
+  - pip install setuptools argparse catkin-pkg PyYAML psutil osrf_pycommon pyenchant sphinxcontrib-spelling
 install:
   # Install catkin_tools
   - python setup.py develop


### PR DESCRIPTION
Now that the project is only targetting Python 3.5+, #561 is no longer required and we can use the most up-to-date version of `sphinx` and `sphinxcontrib-spelling`.