### PR TITLE
Add Travis CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# catkin_tools
+# catkin_tools [![Build Status](https://travis-ci.org/catkin/catkin_tools.svg?branch=master)](https://travis-ci.org/catkin/catkin_tools)
 
 Command line tools for working with [catkin](https://github.com/ros/catkin)
 


### PR DESCRIPTION
This adds a Travis CI badge to the README. It makes it more visible when the build is failing.