### PR TITLE
fix line breaks in CMakeIOBufferProtocol.colorize_cmake

### DIFF
--- a/catkin_tools/jobs/commands/cmake.py
+++ b/catkin_tools/jobs/commands/cmake.py
@@ -150,7 +150,7 @@ class CMakeIOBufferProtocol(IOBufferProtocol):
                         cline = cline.format(*match.groups())
                     break
 
-        return cline + '\r\n'
+        return cline + '\n'
 
 
 class CMakeMakeIOBufferProtocol(IOBufferProtocol):


### PR DESCRIPTION
Just stumbled upon this.
This is the only line, which uses `\r\n`, everywhere else `\ņ` is used.
(with the exception of some `\r` in https://github.com/catkin/catkin_tools/blob/master/catkin_tools/execution/controllers.py)

Did this slip through in https://github.com/catkin/catkin_tools/pull/276/commits/cc842c8775ec8a7a0a13f3bc8a280ea0fa373c14 or was it intended?