### PR TITLE
Remove old platforms from Py2 release, Add Suite3 option for Ubuntu Focal

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,4 +4,5 @@ Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
 Suite: xenial wheezy yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite3: xenial wheezy yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python
 Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
-Suite: trusty vivid wily xenial wheezy yakkety zesty artful bionic jessie stretch buster
+Suite: xenial wheezy yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
This is mimicking ros-infrastructure/catkin_pkg#271 to enable releasing `catkin_tools` into the Focal bootstrap repo for Noetic.