### PR TITLE
Also run tests with Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,16 @@ matrix:
       python: "3.6"
       os: linux
       env: PYTHON=/usr/bin/python3.6 CATKIN_VERSION=indigo-devel
+    - dist: bionic
+      language: python
+      python: "3.7"
+      os: linux
+      env: PYTHON=/usr/bin/python3.7 CATKIN_VERSION=indigo-devel
+    - dist: bionic
+      language: python
+      python: "3.8"
+      os: linux
+      env: PYTHON=/usr/bin/python3.8 CATKIN_VERSION=indigo-devel
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash


### PR DESCRIPTION
Debian Buster uses Python 3.7 and Ubuntu Focal will use Python 3.8