### PR TITLE
Allow extending profiles and merging their contents.

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -207,7 +207,8 @@ class Context(object):
                     if base_profile is None:
                         return config_metadata
                     if base_profile in visited_profiles:
-                        raise IOError("Profile dependency circle detected at dependency from '%s' to '%s'!" % (profile, base_profile))
+                        raise IOError("Profile dependency circle detected at dependency from '%s' to '%s'!"
+                                      % (profile, base_profile))
                     base = get_metadata_recursive(base_profile)
                     base.update(config_metadata)
                     config_metadata = base

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -69,6 +69,7 @@ class Context(object):
         'authors',
         'maintainers',
         'licenses',
+        'extends',
     ]
 
     EXTRA_KEYS = [
@@ -193,8 +194,27 @@ class Context(object):
 
         # Get the metadata stored in the workspace if it was found
         if workspace:
-            config_metadata = metadata.get_metadata(workspace, profile, 'config')
+            key_origins = {}
+            visited_profiles = []
+
+            def get_metadata_recursive(profile):
+                config_metadata = metadata.get_metadata(workspace, profile, 'config')
+                for key in config_metadata.keys():
+                    key_origins[key] = profile
+                visited_profiles.append(profile)
+                if "extends" in config_metadata.keys():
+                    base_profile = config_metadata["extends"]
+                    if base_profile in visited_profiles:
+                        raise IOError("Profile dependency circle detected at dependency from '%s' to '%s'!" % (profile, base_profile))
+                    base = get_metadata_recursive(base_profile)
+                    base.update(config_metadata)
+                    config_metadata = base
+                return config_metadata
+
+            config_metadata = get_metadata_recursive(profile)
+
             context_args.update(config_metadata)
+            context_args["key_origins"] = key_origins
 
         # User-supplied args are used to update stored args
         # Only update context args with given opts which are not none
@@ -223,11 +243,28 @@ class Context(object):
     @classmethod
     def save(cls, context):
         """Save a context in the associated workspace and profile."""
-        metadata.update_metadata(
-            context.workspace,
-            context.profile,
-            'config',
-            context.get_stored_dict())
+
+        data = context.get_stored_dict()
+        files = {}
+
+        def save_in_file(file, key, value):
+            if file in files.keys():
+                files[file][key] = value
+            else:
+                files[file] = {key: value}
+
+        for key, val in data.items():
+            if key in context.key_origins:
+                save_in_file(context.key_origins[key], key, val)
+            else:
+                save_in_file(context.profile, key, val)
+
+        for profile, content in files.items():
+            metadata.update_metadata(
+                context.workspace,
+                profile,
+                'config',
+                content)
 
     def get_stored_dict(self):
         """Get the context parameters which should be stored persistently."""
@@ -253,6 +290,8 @@ class Context(object):
         authors=None,
         maintainers=None,
         licenses=None,
+        extends=None,
+        key_origins={},
         **kwargs
     ):
         """Creates a new Context object, optionally initializing with parameters
@@ -304,6 +343,8 @@ class Context(object):
         :param maintainers: a list of default maintainers
         :type licenses: list
         :param licenses: a list of default licenses
+        :type extends: string
+        :param extends: the name of a profile to use as a base and inherit settings from
         """
         self.__locked = False
 
@@ -311,6 +352,7 @@ class Context(object):
         self.workspace = workspace
 
         self.extend_path = extend_path if extend_path else None
+        self.key_origins = key_origins
 
         self.profile = profile
 
@@ -362,6 +404,8 @@ class Context(object):
         self.cached_cmake_prefix_path = None
         self.env_cmake_prefix_path = None
         self.cmake_prefix_path = None
+
+        self.extends = extends
 
     def load_env(self):
 
@@ -771,6 +815,14 @@ class Context(object):
     @licenses.setter
     def licenses(self, value):
         self.__licenses = value
+
+    @property
+    def extends(self):
+        return self.__extends
+
+    @extends.setter
+    def extends(self, value):
+        self.__extends = value
 
     @property
     def private_devel_path(self):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -204,6 +204,8 @@ class Context(object):
                 visited_profiles.append(profile)
                 if "extends" in config_metadata.keys():
                     base_profile = config_metadata["extends"]
+                    if base_profile is None:
+                        return config_metadata
                     if base_profile in visited_profiles:
                         raise IOError("Profile dependency circle detected at dependency from '%s' to '%s'!" % (profile, base_profile))
                     base = get_metadata_recursive(base_profile)

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -428,8 +428,11 @@ def update_metadata(workspace_path, profile, verb, new_data={}, no_init=False, m
 
     # Update the metadata for this verb
     data.update(new_data)
-    with open(metadata_file_path, 'w') as metadata_file:
-        yaml.dump(data, metadata_file, default_flow_style=False)
+    try:
+        with open(metadata_file_path, 'w') as metadata_file:
+            yaml.dump(data, metadata_file, default_flow_style=False)
+    except PermissionError:
+        print("Could not write to metadata file '%s'!" % (metadata_file_path))
 
     return data
 


### PR DESCRIPTION
This allows profiles to contain the following:
```yaml
extends: <profile name>
```
The `Context` class then loads that base profile and merges the contents of the profiles (last value for a given key wins). When saving the context, the changes are saved in the correct files by keeping a lookup table which stores the file that each parameter was loaded from.

The use case I have for this is that we have many users, each with a separate profile. Most users just want to set a custom `whitelist` or `blacklist` and use default values from another profile for the `cmake_args` etc. With this PR, a lot of copied and pasted YAML code can be removed.

I do not know if this is something that is wanted in this project. If yes, I can add unit tests for the added functionality or refactor the changes if there is a nicer way to implement it (the `key_origins` feels a bit hacky).

Edit: `extends` might not be a good name as it is similar to `extend_path`. Also, I couldn't get the unit tests to work on my machine, so the CI build might fail.