### PR TITLE
Do not ignore metapackages

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -167,9 +167,8 @@ def get_built_unbuilt_packages(context, workspace_packages):
     # Get names of all unbuilt packages
     unbuilt_pkgs = set()
     for path, pkg in workspace_packages.items():
-        if 'metapackage' not in [e.tagname for e in pkg.exports]:
-            if pkg.name not in built_packages:
-                unbuilt_pkgs.add(pkg.name)
+        if pkg.name not in built_packages:
+            unbuilt_pkgs.add(pkg.name)
 
     return built_packages, unbuilt_pkgs
 
@@ -480,11 +479,7 @@ def build_isolated_workspace(
         if pkg.name not in packages_to_be_built_names:
             continue
 
-        # Ignore metapackages
-        if 'metapackage' in [e.tagname for e in pkg.exports]:
-            continue
-
-        # Get actual execution deps
+        # Get actual build deps
         deps = [
             p.name for _, p
             in get_cached_recursive_build_depends_in_workspace(pkg, packages_to_be_built)


### PR DESCRIPTION
Simple fix for #418. Another related issue is https://github.com/catkin/catkin_tools/issues/543.

Metapackages must not be ignored by catkin_tools. The fact that other non-metapackages cannot depend on them according to [REP-140](http://www.ros.org/reps/rep-0140.html#metapackage) does not imply that they do not need to be built and installed at all.

The question on which packages are selected if a list of package names is given at the command line (or as a whitelist) is a different story in my opinion. This is more what issue https://github.com/catkin/catkin_tools/issues/366 is about, but not directly connected to this pull request. I will open a separate PR for that.