### PR TITLE
Doc updates: usage of `-d` on cheat sheet, updated verb .txt files

### DIFF
--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -70,10 +70,10 @@ Build packages with additional CMake args:
   - ``catkin build --save-config --cmake-args -DCMAKE_BUILD_TYPE=Debug``
 
 Build all packages in a given directory:
-  - ``catkin build $(catkin list -u /path/to/folder)``
+  - ``catkin build $(catkin list -u -d /path/to/folder)``
 
 ... or in the current folder:
-  - ``catkin build $(catkin list -u .)``
+  - ``catkin build $(catkin list -u -d .)``
 
 
 Cleaning Build Products

--- a/docs/verbs/cli/catkin_build.txt
+++ b/docs/verbs/cli/catkin_build.txt
@@ -79,19 +79,19 @@ Config:
   --no-env-cache        Don't cache environment variables when re-sourcing the
                         same resultspace.
   --cmake-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to CMake. It
+                        Arbitrary arguments which are passed to CMake. It
                         collects all of following arguments until a "--" is
                         read.
   --no-cmake-args       Pass no additional arguments to CMake.
   --make-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to make.It
+                        Arbitrary arguments which are passed to make. It
                         collects all of following arguments until a "--" is
                         read.
   --no-make-args        Pass no additional arguments to make (does not affect
                         --catkin-make-args).
   --catkin-make-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to make but only
-                        for catkin packages.It collects all of following
+                        Arbitrary arguments which are passed to make but only
+                        for catkin packages. It collects all of following
                         arguments until a "--" is read.
   --no-catkin-make-args
                         Pass no additional arguments to make for catkin

--- a/docs/verbs/cli/catkin_config.txt
+++ b/docs/verbs/cli/catkin_config.txt
@@ -1,13 +1,15 @@
 usage: catkin config [-h] [--workspace WORKSPACE] [--profile PROFILE]
                      [--append-args | --remove-args] [--init]
                      [--extend EXTEND_PATH | --no-extend] [--mkdirs]
+                     [--authors NAME [EMAIL ...] | --maintainers NAME
+                     [EMAIL ...] | --licenses LICENSE [LICENSE ...]]
                      [--whitelist PKG [PKG ...] | --no-whitelist]
                      [--blacklist PKG [PKG ...] | --no-blacklist]
-                     [-s SOURCE_SPACE | --default-source-space]
-                     [-l LOG_SPACE | --default-log-space]
-                     [-b BUILD_SPACE | --default-build-space]
-                     [-d DEVEL_SPACE | --default-devel-space]
-                     [-i INSTALL_SPACE | --default-install-space]
+                     [--build-space BUILD_SPACE | --default-build-space]
+                     [--log-space LOG_SPACE | --default-log-space]
+                     [--install-space INSTALL_SPACE | --default-install-space]
+                     [--devel-space DEVEL_SPACE | --default-devel-space]
+                     [--source-space SOURCE_SPACE | --default-source-space]
                      [-x SPACE_SUFFIX]
                      [--link-devel | --merge-devel | --isolate-devel]
                      [--install | --no-install]
@@ -50,6 +52,16 @@ Workspace Context:
   --mkdirs              Create directories required by the configuration (e.g.
                         source space) if they do not already exist.
 
+Package Create Defaults:
+  Information of default authors/maintainers of created packages
+
+  --authors NAME [EMAIL ...]
+                        Set the default authors of created packages
+  --maintainers NAME [EMAIL ...]
+                        Set the default maintainers of created packages
+  --licenses LICENSE [LICENSE ...]
+                        Set the default licenses of created packages
+
 Package Build Defaults:
   Packages to include or exclude from default build behavior.
 
@@ -67,25 +79,25 @@ Package Build Defaults:
 Spaces:
   Location of parts of the catkin workspace.
 
-  -s SOURCE_SPACE, --source-space SOURCE_SPACE
-                        The path to the source space.
-  --default-source-space
-                        Use the default path to the source space ("src")
-  -l LOG_SPACE, --log-space LOG_SPACE
-                        The path to the log space.
-  --default-log-space   Use the default path to the log space ("logs")
-  -b BUILD_SPACE, --build-space BUILD_SPACE
+  --build-space BUILD_SPACE, -b BUILD_SPACE
                         The path to the build space.
   --default-build-space
                         Use the default path to the build space ("build")
-  -d DEVEL_SPACE, --devel-space DEVEL_SPACE
-                        Sets the target devel space
-  --default-devel-space
-                        Sets the default target devel space ("devel")
-  -i INSTALL_SPACE, --install-space INSTALL_SPACE
-                        Sets the target install space
+  --log-space LOG_SPACE, -l LOG_SPACE
+                        The path to the log space.
+  --default-log-space   Use the default path to the log space ("logs")
+  --install-space INSTALL_SPACE, -i INSTALL_SPACE
+                        The path to the install space.
   --default-install-space
-                        Sets the default target install space ("install")
+                        Use the default path to the install space ("install")
+  --devel-space DEVEL_SPACE, -d DEVEL_SPACE
+                        The path to the devel space.
+  --default-devel-space
+                        Use the default path to the devel space ("devel")
+  --source-space SOURCE_SPACE, -s SOURCE_SPACE
+                        The path to the source space.
+  --default-source-space
+                        Use the default path to the source space ("src")
   -x SPACE_SUFFIX, --space-suffix SPACE_SUFFIX
                         Suffix for build, devel, and install space if they are
                         not otherwise explicitly set.
@@ -131,19 +143,19 @@ Build Options:
   --no-env-cache        Don't cache environment variables when re-sourcing the
                         same resultspace.
   --cmake-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to CMake. It
+                        Arbitrary arguments which are passed to CMake. It
                         collects all of following arguments until a "--" is
                         read.
   --no-cmake-args       Pass no additional arguments to CMake.
   --make-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to make.It
+                        Arbitrary arguments which are passed to make. It
                         collects all of following arguments until a "--" is
                         read.
   --no-make-args        Pass no additional arguments to make (does not affect
                         --catkin-make-args).
   --catkin-make-args ARG [ARG ...]
-                        Arbitrary arguments which are passes to make but only
-                        for catkin packages.It collects all of following
+                        Arbitrary arguments which are passed to make but only
+                        for catkin packages. It collects all of following
                         arguments until a "--" is read.
   --no-catkin-make-args
                         Pass no additional arguments to make for catkin

--- a/docs/verbs/cli/catkin_create.txt
+++ b/docs/verbs/cli/catkin_create.txt
@@ -1,10 +1,16 @@
-usage: catkin create [-h] {pkg} ...
+usage: catkin create [-h] [--workspace WORKSPACE] [--profile PROFILE]
+                     {pkg} ...
 
 Creates catkin workspace resources like packages.
 
 positional arguments:
-  {pkg}       sub-command help
-    pkg       Create a new catkin package.
+  {pkg}                 sub-command help
+    pkg                 Create a new catkin package.
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  --workspace WORKSPACE, -w WORKSPACE
+                        The path to the catkin_tools workspace or a directory
+                        contained within it (default: ".")
+  --profile PROFILE     The name of a config profile to use (default: active
+                        profile)

--- a/docs/verbs/cli/catkin_create_pkg.txt
+++ b/docs/verbs/cli/catkin_create_pkg.txt
@@ -1,4 +1,4 @@
-usage: catkin create pkg [-h] [-p PATH] --rosdistro ROSDISTRO
+usage: catkin create pkg [-h] [-p PATH] [--rosdistro ROSDISTRO]
                          [-v MAJOR.MINOR.PATCH] [-l LICENSE] [-m NAME EMAIL]
                          [-a NAME EMAIL] [-d DESCRIPTION]
                          [--catkin-deps [DEP [DEP ...]]]

--- a/docs/verbs/cli/catkin_list.txt
+++ b/docs/verbs/cli/catkin_list.txt
@@ -1,6 +1,7 @@
 usage: catkin list [-h] [--workspace WORKSPACE] [--profile PROFILE]
                    [--deps | --rdeps] [--depends-on [PKG [PKG ...]]]
-                   [--rdepends-on [PKG [PKG ...]]] [--this] [--quiet]
+                   [--rdepends-on [PKG [PKG ...]]] [--this]
+                   [--directory [DIRECTORY [DIRECTORY ...]]] [--quiet]
                    [--unformatted]
 
 Lists catkin packages in the workspace or other arbitray folders.
@@ -32,6 +33,9 @@ Packages:
                         package(s).
   --this                Show the package which contains the current working
                         directory.
+  --directory [DIRECTORY [DIRECTORY ...]], -d [DIRECTORY [DIRECTORY ...]]
+                        Pass list of directories process all packages in
+                        directory
 
 Interface:
   The behavior of the command-line interface.

--- a/docs/verbs/cli/catkin_profile_list.txt
+++ b/docs/verbs/cli/catkin_profile_list.txt
@@ -1,7 +1,7 @@
-usage: catkin profile list [-h] [--unformatted]
+usage: catkin profile list [-h] [--unformatted] [--active]
 
 optional arguments:
   -h, --help         show this help message and exit
   --unformatted, -u  Print profile list without punctuation and additional
                      details.
-  --active           show only the active profile
+  --active           Print only active profile.


### PR DESCRIPTION
 - The `-d|--directory` feature was introduced in #572
 - Also ran `dump_cli` to update help literally included on verb documentation
   pages. This updated more than just `docs/verbs/cli/catkin_list.txt`, but they
   were in need of an update