### PR TITLE
Cleanup jobs flag parsing

### DIFF
--- a/catkin_tools/spaces/log.py
+++ b/catkin_tools/spaces/log.py
@@ -14,7 +14,7 @@
 
 description = dict(
     default='logs',
-    short_flag='-l',
+    short_flag='-L',
     space='Log Space',
     description='Output generated during the build stages.'
 )

--- a/tests/unit/test_job_flag_regex.py
+++ b/tests/unit/test_job_flag_regex.py
@@ -67,6 +67,12 @@ def test_job_flag_filtering_empty_jl():
         "--jobs --load-average", filtered), JOB_FLAG_ERR % args
 
 
+def test_no_job_flag():
+    args = "jpkg1 lpkg2"
+    filtered = extract_jobs_flags(args)
+    assert filtered is None, JOB_FLAG_ERR % args
+
+
 def test_job_flag_load_float():
     """Test ensures floating point values are handled correctly for load average"""
     args = "pkg1 pkg2 --load-average=1.23"
@@ -88,6 +94,10 @@ def test_job_flag_values():
     valdict = extract_jobs_flags_values(flags)
     assert abs(valdict['load-average'] - 4.0) < 1e-12
     flags = "-l -j"
+    valdict = extract_jobs_flags_values(flags)
+    assert 'load-average' in valdict and 'jobs' in valdict
+    assert valdict['load-average'] is None and valdict['jobs'] is None
+    flags = "--load-average --jobs"
     valdict = extract_jobs_flags_values(flags)
     assert 'load-average' in valdict and 'jobs' in valdict
     assert valdict['load-average'] is None and valdict['jobs'] is None


### PR DESCRIPTION
Summary of the changes:

 * change log space location flag from -l to -L to avoid conflicts (closes #567)
 * clean up regular expressions that were not really readable and add explanatory comments to the new ones
 * add two additional small tests regarding the job flags
 * add `-l` to parser to be shown on `--help`
 * specify type of `-l`, `-j` and `-p` options for more useful error messages