### PR TITLE
fix the interpreter name for Python2 so it can be installed

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,4 +4,5 @@ Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
 Conflicts: python3-catkin-tools
 Conflicts3: python-catkin-tools
 Suite: trusty vivid wily xenial wheezy yakkety zesty artful bionic jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Needed to avoid this issue when installing the resulting deb:

```
% sudo apt install -f python-catkin-tools
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 python-catkin-tools : Depends: python2 (< 2.8) but it is not installable
                       Depends: python2 (>= 2.7) but it is not installable
                       Depends: python2:any (>= 2.6.6-7~) but it is not installable
E: Unable to correct problems, you have held broken packages.
```