### PR TITLE
Fix installation of new cmake files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - pip install setuptools argparse catkin-pkg PyYAML psutil osrf_pycommon pyenchant sphinxcontrib-spelling
 install:
   # Install catkin_tools
-  - python setup.py develop
+  - python setup.py install
 before_script:
   # Install catkin_tools test harness dependencies
   - ./.travis.before_script.bash

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,8 @@ setup(
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={
         'catkin_tools': [
+            'jobs/cmake/python.cmake',
+            'jobs/cmake/python_install_dir.cmake',
             'notifications/resources/linux/catkin_icon.png',
             'notifications/resources/linux/catkin_icon_red.png',
             'verbs/catkin_shell_verbs.bash',


### PR DESCRIPTION
Follow-up on #601: The cmake files were not installed, the fix only worked when installing in development mode. This PR also updates the tests to test on the properly installed, non-development, installation.