### PR TITLE
Report circular dependencies detected by topological_order_packages()

### DIFF
--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -93,6 +93,10 @@ def main(opts):
         try:
             packages = find_packages(folder, warnings=warnings)
             ordered_packages = topological_order_packages(packages)
+            if ordered_packages and ordered_packages[-1][0] is None:
+                print(clr("@{rf}ERROR: Circular dependency within packages:@| "
+                          + ordered_packages[-1][1]), file=sys.stderr)
+                sys.exit(1)
             packages_by_name = {pkg.name: (pth, pkg) for pth, pkg in ordered_packages}
 
             if opts.depends_on or opts.rdepends_on:


### PR DESCRIPTION
When detecting circular dependencies, [catkin_pkg reports them with a special entry `(None, <string of packages>)`](https://github.com/ros-infrastructure/catkin_pkg/blob/e7a6806b370c9318ce8a792149c8906830ba22e6/src/catkin_pkg/topological_order.py#L285-L290).
However, catkin tools didn't handle this situation yet, but assumed that the second component of the tuple is always a package instance, providing a `name` attribute (`pkg.name`):
https://github.com/catkin/catkin_tools/blob/9a3cc3172b1f72e3e1d364d7dfd000abb5712e53/catkin_tools/verbs/catkin_list/cli.py#L95-L96
causing the following exception:
```bash
$ catkin list
Traceback (most recent call last):
  File "/usr/local/bin/catkin", line 11, in <module>
    load_entry_point('catkin-tools', 'console_scripts', 'catkin')()
  File "/homes/rhaschke/src/ros/catkin_tools/catkin_tools/commands/catkin.py", line 272, in main
    catkin_main(sysargs)
  File "/homes/rhaschke/src/ros/catkin_tools/catkin_tools/commands/catkin.py", line 267, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/homes/rhaschke/src/ros/catkin_tools/catkin_tools/verbs/catkin_list/cli.py", line 96, in main
    packages_by_name = {pkg.name: (pth, pkg) for pth, pkg in ordered_packages}
  File "/homes/rhaschke/src/ros/catkin_tools/catkin_tools/verbs/catkin_list/cli.py", line 96, in <dictcomp>
    packages_by_name = {pkg.name: (pth, pkg) for pth, pkg in ordered_packages}
AttributeError: 'str' object has no attribute 'name'
```
