### PR TITLE
Remove blacklist/whitelist Terms

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -64,7 +64,7 @@ class Context(object):
         'use_internal_make_jobserver',
         'use_env_cache',
         'catkin_make_args',
-        'whitelist',
+        'allowlist',
         'denylist',
         'authors',
         'maintainers',
@@ -293,7 +293,7 @@ class Context(object):
         use_env_cache=False,
         catkin_make_args=None,
         space_suffix=None,
-        whitelist=None,
+        allowlist=None,
         denylist=None,
         authors=None,
         maintainers=None,
@@ -340,8 +340,8 @@ class Context(object):
         :type catkin_make_args: list
         :param space_suffix: suffix for build, devel, and install spaces which are not explicitly set.
         :type space_suffix: str
-        :param whitelist: a list of packages to build by default
-        :type whitelist: list
+        :param allowlist: a list of packages to build by default
+        :type allowlist: list
         :param denylist: a list of packages to ignore by default
         :type denylist: list
         :raises: ValueError if workspace or source space does not exist
@@ -379,8 +379,8 @@ class Context(object):
 
         self.destdir = os.environ['DESTDIR'] if 'DESTDIR' in os.environ else None
 
-        # Handle package whitelist/denylist
-        self.whitelist = whitelist or []
+        # Handle package allowlist/denylist
+        self.allowlist = allowlist or []
         self.denylist = denylist or []
 
         # Handle default authors/maintainers
@@ -546,7 +546,7 @@ class Context(object):
                 clr("@{cf}Cache Job Environments:@|      @{yf}{_Context__use_env_cache}@|"),
             ],
             [
-                clr("@{cf}Whitelisted Packages:@|        @{yf}{whitelisted_packages}@|"),
+                clr("@{cf}Whitelisted Packages:@|        @{yf}{allowlisted_packages}@|"),
                 clr("@{cf}Blacklisted Packages:@|        @{yf}{denylisted_packages}@|"),
             ]
         ]
@@ -592,7 +592,7 @@ class Context(object):
             'devel_missing': existence_str(self.devel_space_abs),
             'install_missing': existence_str(self.install_space_abs, used=self.__install),
             'destdir_missing': existence_str(self.destdir, used=self.destdir),
-            'whitelisted_packages': ' '.join(self.__whitelist or ['None']),
+            'allowlisted_packages': ' '.join(self.__allowlist or ['None']),
             'denylisted_packages': ' '.join(self.__denylist or ['None']),
         }
         subs.update(**self.__dict__)
@@ -785,12 +785,12 @@ class Context(object):
         self.__packages = value
 
     @property
-    def whitelist(self):
-        return self.__whitelist
+    def allowlist(self):
+        return self.__allowlist
 
-    @whitelist.setter
-    def whitelist(self, value):
-        self.__whitelist = value
+    @allowlist.setter
+    def allowlist(self, value):
+        self.__allowlist = value
 
     @property
     def denylist(self):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -65,7 +65,7 @@ class Context(object):
         'use_env_cache',
         'catkin_make_args',
         'whitelist',
-        'blacklist',
+        'denylist',
         'authors',
         'maintainers',
         'licenses',
@@ -294,7 +294,7 @@ class Context(object):
         catkin_make_args=None,
         space_suffix=None,
         whitelist=None,
-        blacklist=None,
+        denylist=None,
         authors=None,
         maintainers=None,
         licenses=None,
@@ -342,8 +342,8 @@ class Context(object):
         :type space_suffix: str
         :param whitelist: a list of packages to build by default
         :type whitelist: list
-        :param blacklist: a list of packages to ignore by default
-        :type blacklist: list
+        :param denylist: a list of packages to ignore by default
+        :type denylist: list
         :raises: ValueError if workspace or source space does not exist
         :type authors: list
         :param authors: a list of default authors
@@ -379,9 +379,9 @@ class Context(object):
 
         self.destdir = os.environ['DESTDIR'] if 'DESTDIR' in os.environ else None
 
-        # Handle package whitelist/blacklist
+        # Handle package whitelist/denylist
         self.whitelist = whitelist or []
-        self.blacklist = blacklist or []
+        self.denylist = denylist or []
 
         # Handle default authors/maintainers
         self.authors = authors or []
@@ -547,7 +547,7 @@ class Context(object):
             ],
             [
                 clr("@{cf}Whitelisted Packages:@|        @{yf}{whitelisted_packages}@|"),
-                clr("@{cf}Blacklisted Packages:@|        @{yf}{blacklisted_packages}@|"),
+                clr("@{cf}Blacklisted Packages:@|        @{yf}{denylisted_packages}@|"),
             ]
         ]
 
@@ -593,7 +593,7 @@ class Context(object):
             'install_missing': existence_str(self.install_space_abs, used=self.__install),
             'destdir_missing': existence_str(self.destdir, used=self.destdir),
             'whitelisted_packages': ' '.join(self.__whitelist or ['None']),
-            'blacklisted_packages': ' '.join(self.__blacklist or ['None']),
+            'denylisted_packages': ' '.join(self.__denylist or ['None']),
         }
         subs.update(**self.__dict__)
         # Get the width of the shell
@@ -793,12 +793,12 @@ class Context(object):
         self.__whitelist = value
 
     @property
-    def blacklist(self):
-        return self.__blacklist
+    def denylist(self):
+        return self.__denylist
 
-    @blacklist.setter
-    def blacklist(self, value):
-        self.__blacklist = value
+    @denylist.setter
+    def denylist(self, value):
+        self.__denylist = value
 
     @property
     def authors(self):

--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -188,7 +188,7 @@ class ConsoleStatusController(threading.Thread):
             jobs,
             max_toplevel_jobs,
             available_jobs,
-            whitelisted_jobs,
+            allowlisted_jobs,
             denylisted_jobs,
             event_queue,
             show_notifications=False,
@@ -251,7 +251,7 @@ class ConsoleStatusController(threading.Thread):
 
         self.available_jobs = available_jobs
         self.denylisted_jobs = denylisted_jobs
-        self.whitelisted_jobs = whitelisted_jobs
+        self.allowlisted_jobs = allowlisted_jobs
 
         # Compute the max job id length when combined with stage labels
         self.max_jid_length = 1
@@ -293,7 +293,7 @@ class ConsoleStatusController(threading.Thread):
         faileds = {}
         ignoreds = {}
         abandoneds = {}
-        non_whitelisted = {}
+        non_allowlisted = {}
         denylisted = {}
 
         # Give each package an output template to use
@@ -302,8 +302,8 @@ class ConsoleStatusController(threading.Thread):
                 denylisted[jid] = templates['ignored']
             elif jid not in self.jobs:
                 ignoreds[jid] = templates['ignored']
-            elif len(self.whitelisted_jobs) > 0 and jid not in self.whitelisted_jobs:
-                non_whitelisted[jid] = templates['ignored']
+            elif len(self.allowlisted_jobs) > 0 and jid not in self.allowlisted_jobs:
+                non_allowlisted[jid] = templates['ignored']
             elif jid in completed_jobs:
                 if jid in failed_jobs:
                     faileds[jid] = templates['failed']
@@ -327,12 +327,12 @@ class ConsoleStatusController(threading.Thread):
             wide_log(clr("[{}] No {} succeeded.").format(self.label, self.jobs_label))
             wide_log("")
 
-        # Print out whitelisted jobs
-        if len(non_whitelisted) > 0:
+        # Print out allowlisted jobs
+        if len(non_allowlisted) > 0:
             wide_log("")
-            wide_log(clr("[{}] Non-whitelisted {}:").format(self.label, self.jobs_label))
+            wide_log(clr("[{}] Non-allowlisted {}:").format(self.label, self.jobs_label))
             wide_log("")
-            print_items_in_columns(sorted(non_whitelisted.items()), number_of_columns)
+            print_items_in_columns(sorted(non_allowlisted.items()), number_of_columns)
 
         # Print out denylisted jobs
         if len(denylisted) > 0:

--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -125,8 +125,8 @@ _color_translation_map = {
     "[{}] Ignored: None.":
     fmt("[{}]   @/@!@{kf}Ignored:   None.@|"),
 
-    "[{}] Ignored: {} {} were skipped or are blacklisted.":
-    fmt("[{}]   @/@!@{pf}Ignored:@|   @/@!{}@| @/{} were skipped or are blacklisted.@|"),
+    "[{}] Ignored: {} {} were skipped or are denylisted.":
+    fmt("[{}]   @/@!@{pf}Ignored:@|   @/@!{}@| @/{} were skipped or are denylisted.@|"),
 
     "[{}] Failed: No {} failed.":
     fmt("[{}]   @/@!@{kf}Failed:    None.@|"),
@@ -189,7 +189,7 @@ class ConsoleStatusController(threading.Thread):
             max_toplevel_jobs,
             available_jobs,
             whitelisted_jobs,
-            blacklisted_jobs,
+            denylisted_jobs,
             event_queue,
             show_notifications=False,
             show_stage_events=False,
@@ -250,7 +250,7 @@ class ConsoleStatusController(threading.Thread):
         self.jobs = dict([(j.jid, j) for j in jobs])
 
         self.available_jobs = available_jobs
-        self.blacklisted_jobs = blacklisted_jobs
+        self.denylisted_jobs = denylisted_jobs
         self.whitelisted_jobs = whitelisted_jobs
 
         # Compute the max job id length when combined with stage labels
@@ -294,12 +294,12 @@ class ConsoleStatusController(threading.Thread):
         ignoreds = {}
         abandoneds = {}
         non_whitelisted = {}
-        blacklisted = {}
+        denylisted = {}
 
         # Give each package an output template to use
         for jid in self.available_jobs:
-            if jid in self.blacklisted_jobs:
-                blacklisted[jid] = templates['ignored']
+            if jid in self.denylisted_jobs:
+                denylisted[jid] = templates['ignored']
             elif jid not in self.jobs:
                 ignoreds[jid] = templates['ignored']
             elif len(self.whitelisted_jobs) > 0 and jid not in self.whitelisted_jobs:
@@ -334,12 +334,12 @@ class ConsoleStatusController(threading.Thread):
             wide_log("")
             print_items_in_columns(sorted(non_whitelisted.items()), number_of_columns)
 
-        # Print out blacklisted jobs
-        if len(blacklisted) > 0:
+        # Print out denylisted jobs
+        if len(denylisted) > 0:
             wide_log("")
             wide_log(clr("[{}] Blacklisted {}:").format(self.label, self.jobs_label))
             wide_log("")
-            print_items_in_columns(sorted(blacklisted.items()), number_of_columns)
+            print_items_in_columns(sorted(denylisted.items()), number_of_columns)
 
         # Print out jobs that failed
         if len(faileds) > 0:
@@ -388,7 +388,7 @@ class ConsoleStatusController(threading.Thread):
                 self.label))
         else:
             notification_msg.append("{} {} were skipped.".format(len(all_ignored_jobs), self.jobs_label))
-            wide_log(clr('[{}] Ignored: {} {} were skipped or are blacklisted.').format(
+            wide_log(clr('[{}] Ignored: {} {} were skipped or are denylisted.').format(
                 self.label,
                 len(all_ignored_jobs),
                 self.jobs_label))

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -234,8 +234,8 @@ def link_devel_products(
     # List of files that collide
     files_that_collide = []
 
-    # Select the blacklist
-    blacklist = DEVEL_LINK_PREBUILD_BLACKLIST if prebuild else DEVEL_LINK_BLACKLIST
+    # Select the denylist
+    denylist = DEVEL_LINK_PREBUILD_BLACKLIST if prebuild else DEVEL_LINK_BLACKLIST
 
     # Gather all of the files in the devel space
     for source_path, dirs, files in os.walk(source_devel_path):
@@ -275,8 +275,8 @@ def link_devel_products(
         # create symbolic links from the source to the dest
         for filename in files:
 
-            # Don't link files on the blacklist unless this is a prebuild package
-            if os.path.relpath(os.path.join(source_path, filename), source_devel_path) in blacklist:
+            # Don't link files on the denylist unless this is a prebuild package
+            if os.path.relpath(os.path.join(source_path, filename), source_devel_path) in denylist:
                 continue
 
             source_file = os.path.join(source_path, filename)

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -137,8 +137,8 @@ def get_resultspace_environment(result_space_path, base_env=None, quiet=False, c
         '"typeset -px"'
     ])
 
-    # Define some "blacklisted" environment variables which shouldn't be copied
-    blacklisted_keys = ('_', 'PWD')
+    # Define some "denylisted" environment variables which shouldn't be copied
+    denylisted_keys = ('_', 'PWD')
     env_dict = {}
 
     try:
@@ -159,7 +159,7 @@ def get_resultspace_environment(result_space_path, base_env=None, quiet=False, c
         env_dict = {
             k: v
             for k, v in parse_env_str(lines).items()
-            if k not in blacklisted_keys
+            if k not in denylisted_keys
         }
 
         # Check to make sure we got some kind of environment

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -128,19 +128,19 @@ def determine_packages_to_be_built(packages, context, workspace_packages):
         else:
             packages_to_be_built = ordered_packages
 
-    # Filter packages with blacklist
-    if len(context.blacklist) > 0:
-        # Expand glob patterns in blacklist
-        blacklist = []
-        for blacklisted_package in context.blacklist:
-            blacklist.extend(expand_glob_package(blacklisted_package, workspace_package_names))
-        # Apply blacklist to packages and dependencies
+    # Filter packages with denylist
+    if len(context.denylist) > 0:
+        # Expand glob patterns in denylist
+        denylist = []
+        for denylisted_package in context.denylist:
+            denylist.extend(expand_glob_package(denylisted_package, workspace_package_names))
+        # Apply denylist to packages and dependencies
         packages_to_be_built = [
             (path, pkg) for path, pkg in packages_to_be_built
-            if (pkg.name not in blacklist or pkg.name in packages)]
+            if (pkg.name not in denylist or pkg.name in packages)]
         packages_to_be_built_deps = [
             (path, pkg) for path, pkg in packages_to_be_built_deps
-            if (pkg.name not in blacklist or pkg.name in packages)]
+            if (pkg.name not in denylist or pkg.name in packages)]
 
     return packages_to_be_built, packages_to_be_built_deps, ordered_packages
 
@@ -526,7 +526,7 @@ def build_isolated_workspace(
             n_jobs,
             [pkg.name for _, pkg in context.packages],
             [p for p in context.whitelist],
-            [p for p in context.blacklist],
+            [p for p in context.denylist],
             event_queue,
             show_notifications=not no_notify,
             show_active_status=not no_status,

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -118,13 +118,13 @@ def determine_packages_to_be_built(packages, context, workspace_packages):
                 pkg_deps = get_cached_recursive_build_depends_in_workspace(package, ordered_packages)
                 packages_to_be_built_deps.extend(pkg_deps)
     else:
-        # Only use whitelist when no other packages are specified
-        if len(context.whitelist) > 0:
-            # Expand glob patterns in whitelist
-            whitelist = []
-            for whitelisted_package in context.whitelist:
-                whitelist.extend(expand_glob_package(whitelisted_package, workspace_package_names))
-            packages_to_be_built = [p for p in ordered_packages if (p[1].name in whitelist)]
+        # Only use allowlist when no other packages are specified
+        if len(context.allowlist) > 0:
+            # Expand glob patterns in allowlist
+            allowlist = []
+            for allowlisted_package in context.allowlist:
+                allowlist.extend(expand_glob_package(allowlisted_package, workspace_package_names))
+            packages_to_be_built = [p for p in ordered_packages if (p[1].name in allowlist)]
         else:
             packages_to_be_built = ordered_packages
 
@@ -525,7 +525,7 @@ def build_isolated_workspace(
             jobs,
             n_jobs,
             [pkg.name for _, pkg in context.packages],
-            [p for p in context.whitelist],
+            [p for p in context.allowlist],
             [p for p in context.denylist],
             event_queue,
             show_notifications=not no_notify,

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -165,7 +165,7 @@ def clean_packages(
         1,
         [pkg.name for _, pkg in context.packages],
         [p for p in context.whitelist],
-        [p for p in context.blacklist],
+        [p for p in context.denylist],
         event_queue,
         show_notifications=False,
         show_active_status=False,

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -164,7 +164,7 @@ def clean_packages(
         jobs,
         1,
         [pkg.name for _, pkg in context.packages],
-        [p for p in context.whitelist],
+        [p for p in context.allowlist],
         [p for p in context.denylist],
         event_queue,
         show_notifications=False,

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -135,7 +135,7 @@ def prepare_arguments(parser):
     add('--orphans', action='store_true', default=False,
         help='Remove products from packages are no longer in the source space. '
         'Note that this also removes packages which are '
-        'blacklisted or which contain `CATKIN_INGORE` marker files.')
+        'denylisted or which contain `CATKIN_INGORE` marker files.')
 
     # Advanced group
     advanced_group = parser.add_argument_group(

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -72,12 +72,12 @@ def prepare_arguments(parser):
     lists_group = parser.add_argument_group(
         'Package Build Defaults', 'Packages to include or exclude from default build behavior.')
     add = lists_group.add_mutually_exclusive_group().add_argument
-    add('--whitelist', metavar="PKG", dest='whitelist', nargs="+", required=False, type=str, default=None,
-        help='Set the packages on the whitelist. If the whitelist is non-empty, '
-        'only the packages on the whitelist are built with a bare call to '
+    add('--allowlist', metavar="PKG", dest='allowlist', nargs="+", required=False, type=str, default=None,
+        help='Set the packages on the allowlist. If the allowlist is non-empty, '
+        'only the packages on the allowlist are built with a bare call to '
         '`catkin build`.')
-    add('--no-whitelist', dest='whitelist', action='store_const', const=[], default=None,
-        help='Clear all packages from the whitelist.')
+    add('--no-allowlist', dest='allowlist', action='store_const', const=[], default=None,
+        help='Clear all packages from the allowlist.')
     add = lists_group.add_mutually_exclusive_group().add_argument
     add('--denylist', metavar="PKG", dest='denylist', nargs="+", required=False, type=str, default=None,
         help='Set the packages on the denylist. Packages on the denylist are '

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -79,11 +79,11 @@ def prepare_arguments(parser):
     add('--no-whitelist', dest='whitelist', action='store_const', const=[], default=None,
         help='Clear all packages from the whitelist.')
     add = lists_group.add_mutually_exclusive_group().add_argument
-    add('--blacklist', metavar="PKG", dest='blacklist', nargs="+", required=False, type=str, default=None,
-        help='Set the packages on the blacklist. Packages on the blacklist are '
+    add('--denylist', metavar="PKG", dest='denylist', nargs="+", required=False, type=str, default=None,
+        help='Set the packages on the denylist. Packages on the denylist are '
         'not built with a bare call to `catkin build`.')
-    add('--no-blacklist', dest='blacklist', action='store_const', const=[], default=None,
-        help='Clear all packages from the blacklist.')
+    add('--no-denylist', dest='denylist', action='store_const', const=[], default=None,
+        help='Clear all packages from the denylist.')
 
     spaces_group = parser.add_argument_group('Spaces', 'Location of parts of the catkin workspace.')
     Context.setup_space_keys()

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -281,9 +281,9 @@ _catkin_config_complete() {
     '--init[Initialize a workspace]'\
     {-e,--extend}'[Explicitly extend another workspace]:workspace:_files'\
     '--no-extend[Unset the explicit extension of another workspace]'\
-    '(--no-whitelist)--whitelist[Set the packages on the whitelist]:package:->packages'\
+    '(--no-allowlist)--allowlist[Set the packages on the allowlist]:package:->packages'\
     '(--no-denylist)--denylist[Set the packages on the denylist]:package:->packages'\
-    '(--whitelist)--no-whitelist[Clear the whitelist]'\
+    '(--allowlist)--no-allowlist[Clear the allowlist]'\
     '(--denylist)--no-denylist[Clear the denylist]'\
     '(--default-source-space)'{-s,--source-space}'[Source space path]'\
     '(--default-build-space)'{-b,--build-space}'[Build space path]'\

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -282,9 +282,9 @@ _catkin_config_complete() {
     {-e,--extend}'[Explicitly extend another workspace]:workspace:_files'\
     '--no-extend[Unset the explicit extension of another workspace]'\
     '(--no-whitelist)--whitelist[Set the packages on the whitelist]:package:->packages'\
-    '(--no-blacklist)--blacklist[Set the packages on the blacklist]:package:->packages'\
+    '(--no-denylist)--denylist[Set the packages on the denylist]:package:->packages'\
     '(--whitelist)--no-whitelist[Clear the whitelist]'\
-    '(--blacklist)--no-blacklist[Clear the blacklist]'\
+    '(--denylist)--no-denylist[Clear the denylist]'\
     '(--default-source-space)'{-s,--source-space}'[Source space path]'\
     '(--default-build-space)'{-b,--build-space}'[Build space path]'\
     '(--default-devel-space)'{-d,--devel-space}'[Devel space path]'\

--- a/completion/catkin_tools-completion.bash
+++ b/completion/catkin_tools-completion.bash
@@ -88,7 +88,7 @@ _catkin()
       local catkin_config_opts=$(catkin config --help 2>&1 | sed -ne $OPTS_FILTER | sort -u)
       COMPREPLY=($(compgen -W "${catkin_config_opts}" -- ${cur}))
 
-      # list package names when --whitelist or --denylist was given as last option
+      # list package names when --allowlist or --denylist was given as last option
       if [[ ${cur} != -* && $(_catkin_last_option) == --*list ]] ; then
         COMPREPLY+=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       fi

--- a/completion/catkin_tools-completion.bash
+++ b/completion/catkin_tools-completion.bash
@@ -88,7 +88,7 @@ _catkin()
       local catkin_config_opts=$(catkin config --help 2>&1 | sed -ne $OPTS_FILTER | sort -u)
       COMPREPLY=($(compgen -W "${catkin_config_opts}" -- ${cur}))
 
-      # list package names when --whitelist or --blacklist was given as last option
+      # list package names when --whitelist or --denylist was given as last option
       if [[ ${cur} != -* && $(_catkin_last_option) == --*list ]] ; then
         COMPREPLY+=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       fi

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -297,7 +297,7 @@ Note that some ``catkin_make`` options can only be achieved with the ``catkin co
 -------------------------------------------------  --------------------------------------------
  ``-DCATKIN_INSTALL_PREFIX=PATH``                   ``config --install-space PATH`` [1]_
 -------------------------------------------------  --------------------------------------------
- ``-DCATKIN_WHITELIST_PACKAGES="PKG[;PKG ...]"``    ``config --whitelist PKG [PKG ...]`` [1]_
+ ``-DCATKIN_WHITELIST_PACKAGES="PKG[;PKG ...]"``    ``config --allowlist PKG [PKG ...]`` [1]_
 =================================================  ============================================
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -37,8 +37,8 @@ Unformatted
 Uninstalling
 unsatisfiable
 unsetting
-whitelist
-whitelisted
+allowlist
+allowlisted
 Whitelisting
 workflow
 workspace

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -31,7 +31,7 @@ List-type options include:
  - ``--cmake-args``
  - ``--make-args``
  - ``--catkin-make-args``
- - ``--whitelist``
+ - ``--allowlist``
  - ``--denylist``
 
 Installing Packages
@@ -138,21 +138,21 @@ This can be done with the ``--extend`` option like so:
 Whitelisting and Blacklisting Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Packages can be added to a package *whitelist* or *denylist* in order to change which packages get built.
-If the *whitelist*  is non-empty, then a call to ``catkin build`` with no specific package names will only build the packages on the *whitelist*.
-This means that you can still build packages not on the *whitelist*, but only if they are named explicitly or are dependencies of other whitelisted packages.
+Packages can be added to a package *allowlist* or *denylist* in order to change which packages get built.
+If the *allowlist*  is non-empty, then a call to ``catkin build`` with no specific package names will only build the packages on the *allowlist*.
+This means that you can still build packages not on the *allowlist*, but only if they are named explicitly or are dependencies of other allowlisted packages.
 
-To set the whitelist, you can call the following command:
-
-.. code-block:: text
-
-    catkin config --whitelist foo bar
-
-To clear the whitelist, you can use the ``--no-whitelist`` option:
+To set the allowlist, you can call the following command:
 
 .. code-block:: text
 
-    catkin config --no-whitelist
+    catkin config --allowlist foo bar
+
+To clear the allowlist, you can use the ``--no-allowlist`` option:
+
+.. code-block:: text
+
+    catkin config --no-allowlist
 
 If the *denylist* is non-empty, it will filter the packages to be built in all cases except where a given package is named explicitly.
 This means that denylisted packages will not be built even if another package in the workspace depends on them.
@@ -174,7 +174,7 @@ To clear the denylist, you can use the ``--no-denylist`` option:
 
     catkin config --no-denylist
 
-Note that you can still build packages on the denylist and whitelist by passing their names to ``catkin build`` explicitly.
+Note that you can still build packages on the denylist and allowlist by passing their names to ``catkin build`` explicitly.
 
 Accelerated Building with Environment Caching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -32,7 +32,7 @@ List-type options include:
  - ``--make-args``
  - ``--catkin-make-args``
  - ``--whitelist``
- - ``--blacklist``
+ - ``--denylist``
 
 Installing Packages
 ^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ This can be done with the ``--extend`` option like so:
 Whitelisting and Blacklisting Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Packages can be added to a package *whitelist* or *blacklist* in order to change which packages get built.
+Packages can be added to a package *whitelist* or *denylist* in order to change which packages get built.
 If the *whitelist*  is non-empty, then a call to ``catkin build`` with no specific package names will only build the packages on the *whitelist*.
 This means that you can still build packages not on the *whitelist*, but only if they are named explicitly or are dependencies of other whitelisted packages.
 
@@ -154,27 +154,27 @@ To clear the whitelist, you can use the ``--no-whitelist`` option:
 
     catkin config --no-whitelist
 
-If the *blacklist* is non-empty, it will filter the packages to be built in all cases except where a given package is named explicitly.
-This means that blacklisted packages will not be built even if another package in the workspace depends on them.
+If the *denylist* is non-empty, it will filter the packages to be built in all cases except where a given package is named explicitly.
+This means that denylisted packages will not be built even if another package in the workspace depends on them.
 
 .. note::
 
     Blacklisting a package does not remove it's build directory or build
     products, it only prevents it from being rebuilt.
 
-To set the blacklist, you can call the following command:
+To set the denylist, you can call the following command:
 
 .. code-block:: text
 
-    catkin config --blacklist baz
+    catkin config --denylist baz
 
-To clear the blacklist, you can use the ``--no-blacklist`` option:
+To clear the denylist, you can use the ``--no-denylist`` option:
 
 .. code-block:: text
 
-    catkin config --no-blacklist
+    catkin config --no-denylist
 
-Note that you can still build packages on the blacklist and whitelist by passing their names to ``catkin build`` explicitly.
+Note that you can still build packages on the denylist and whitelist by passing their names to ``catkin build`` explicitly.
 
 Accelerated Building with Environment Caching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/verbs/cli/catkin_clean.txt
+++ b/docs/verbs/cli/catkin_clean.txt
@@ -48,7 +48,7 @@ Packages:
                         cleaned.
   --orphans             Remove products from packages are no longer in the
                         source space. Note that this also removes packages
-                        which are blacklisted or which contain `CATKIN_INGORE`
+                        which are denylisted or which contain `CATKIN_INGORE`
                         marker files.
 
 Advanced:

--- a/docs/verbs/cli/catkin_config.txt
+++ b/docs/verbs/cli/catkin_config.txt
@@ -4,7 +4,7 @@ usage: catkin config [-h] [--workspace WORKSPACE] [--profile PROFILE]
                      [--authors NAME [EMAIL ...] | --maintainers NAME
                      [EMAIL ...] | --licenses LICENSE [LICENSE ...]]
                      [--whitelist PKG [PKG ...] | --no-whitelist]
-                     [--blacklist PKG [PKG ...] | --no-blacklist]
+                     [--denylist PKG [PKG ...] | --no-denylist]
                      [--build-space BUILD_SPACE | --default-build-space]
                      [--log-space LOG_SPACE | --default-log-space]
                      [--install-space INSTALL_SPACE | --default-install-space]
@@ -70,11 +70,11 @@ Package Build Defaults:
                         non-empty, only the packages on the whitelist are
                         built with a bare call to `catkin build`.
   --no-whitelist        Clear all packages from the whitelist.
-  --blacklist PKG [PKG ...]
-                        Set the packages on the blacklist. Packages on the
-                        blacklist are not built with a bare call to `catkin
+  --denylist PKG [PKG ...]
+                        Set the packages on the denylist. Packages on the
+                        denylist are not built with a bare call to `catkin
                         build`.
-  --no-blacklist        Clear all packages from the blacklist.
+  --no-denylist        Clear all packages from the denylist.
 
 Spaces:
   Location of parts of the catkin workspace.

--- a/docs/verbs/cli/catkin_config.txt
+++ b/docs/verbs/cli/catkin_config.txt
@@ -3,7 +3,7 @@ usage: catkin config [-h] [--workspace WORKSPACE] [--profile PROFILE]
                      [--extend EXTEND_PATH | --no-extend] [--mkdirs]
                      [--authors NAME [EMAIL ...] | --maintainers NAME
                      [EMAIL ...] | --licenses LICENSE [LICENSE ...]]
-                     [--whitelist PKG [PKG ...] | --no-whitelist]
+                     [--allowlist PKG [PKG ...] | --no-allowlist]
                      [--denylist PKG [PKG ...] | --no-denylist]
                      [--build-space BUILD_SPACE | --default-build-space]
                      [--log-space LOG_SPACE | --default-log-space]
@@ -65,11 +65,11 @@ Package Create Defaults:
 Package Build Defaults:
   Packages to include or exclude from default build behavior.
 
-  --whitelist PKG [PKG ...]
-                        Set the packages on the whitelist. If the whitelist is
-                        non-empty, only the packages on the whitelist are
+  --allowlist PKG [PKG ...]
+                        Set the packages on the allowlist. If the allowlist is
+                        non-empty, only the packages on the allowlist are
                         built with a bare call to `catkin build`.
-  --no-whitelist        Clear all packages from the whitelist.
+  --no-allowlist        Clear all packages from the allowlist.
   --denylist PKG [PKG ...]
                         Set the packages on the denylist. Packages on the
                         denylist are not built with a bare call to `catkin

--- a/tests/system/verbs/catkin_build/test_deny_allow_lists.py
+++ b/tests/system/verbs/catkin_build/test_deny_allow_lists.py
@@ -9,8 +9,8 @@ BUILD = ['build', '--no-notify', '--no-status']
 CLEAN = ['clean', '--all', '--yes']  # , '--no-notify', '--no-color', '--no-status']
 
 
-def test_whitelist():
-    """Test building whitelisted packages only"""
+def test_allowlist():
+    """Test building allowlisted packages only"""
     pass  # TODO: Write test
 
 
@@ -19,6 +19,6 @@ def test_denylist():
     pass  # TODO: Write test
 
 
-def test_denylist_whitelist():
-    """Test building with non-empty denylist and whitelist"""
+def test_denylist_allowlist():
+    """Test building with non-empty denylist and allowlist"""
     pass  # TODO: Write test

--- a/tests/system/verbs/catkin_build/test_deny_allow_lists.py
+++ b/tests/system/verbs/catkin_build/test_deny_allow_lists.py
@@ -14,11 +14,11 @@ def test_whitelist():
     pass  # TODO: Write test
 
 
-def test_blacklist():
-    """Test building all packages except blacklisted packages"""
+def test_denylist():
+    """Test building all packages except denylisted packages"""
     pass  # TODO: Write test
 
 
-def test_blacklist_whitelist():
-    """Test building with non-empty blacklist and whitelist"""
+def test_denylist_whitelist():
+    """Test building with non-empty denylist and whitelist"""
     pass  # TODO: Write test

--- a/tests/system/verbs/catkin_build/test_modify_ws.py
+++ b/tests/system/verbs/catkin_build/test_modify_ws.py
@@ -29,6 +29,6 @@ def test_ignore_package():
     pass  # TODO: Implement this for various dependency relationships
 
 
-def test_deblacklist():
-    """Test build behavior when removing a package from the blacklist that has yet to be built"""
+def test_dedenylist():
+    """Test build behavior when removing a package from the denylist that has yet to be built"""
     pass  # TODO: Implement this for various dependency relationships


### PR DESCRIPTION
Given the recent wave of renaming terms to be more inclusive, I thought it might be worth removing the terms "blacklist" and "whitelist".

This PR replaces the terms with "denylist" and "allowlist" respectively (one of the proposed replacements for these terms for Linux kernel), but I would be happy to change this patch to use other terms upon request.