### PR TITLE
In catkin build, preserve original job list topological ordering

### DIFF
--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -344,7 +344,10 @@ def execute_jobs(
             new_queued_jobs, pending_jobs = split(
                 pending_jobs,
                 lambda j: j.all_deps_completed(completed_jobs))
-            queued_jobs.extend(new_queued_jobs)
+            new_queued_jobs.extend(queued_jobs)
+
+            # queued jobs should preserve the original topological sort of jobs
+            queued_jobs = [j for j in jobs if j in new_queued_jobs]
 
             # Notify of newly queued jobs
             for queued_job in new_queued_jobs:


### PR DESCRIPTION
Specifically, when moving from jobs from pending to queued.

The current code just appends the jobs moved from pending to queued to the end of queued. This changes the order jobs in which jobs are run. This isn't a bug, but is needed to get the benefit from https://github.com/ros-infrastructure/catkin_pkg/pull/293, assuming that's merged.

This PR changes the behavior such that the original ordering of the jobs is preserved.
