### PR TITLE
remove older py35+xenial config and add py39+focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@
 language: generic
 matrix:
   include:
-    - dist: xenial
-      language: python
-      python: "3.5"
-      os: linux
-      env: PYTHON=/usr/bin/python3.5 CATKIN_VERSION=indigo-devel
     - dist: bionic
       language: python
       python: "3.6"
@@ -22,6 +17,11 @@ matrix:
       python: "3.8"
       os: linux
       env: PYTHON=/usr/bin/python3.8 CATKIN_VERSION=indigo-devel
+    - dist: focal
+      language: python
+      python: "3.9"
+      os: linux
+      env: PYTHON=/usr/bin/python3.9 CATKIN_VERSION=indigo-devel
 before_install:
   # Install catkin_tools dependencies
   - source .travis.before_install.bash


### PR DESCRIPTION
Addresses https://github.com/catkin/catkin_tools/pull/634#issuecomment-741904218

Decided to also add a focal configuration with the latest python. I can remove if it is unnecessary.