### PR TITLE
Install python2 before travis runs.

### DIFF
--- a/.travis.before_install.bash
+++ b/.travis.before_install.bash
@@ -5,6 +5,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-updates main universe restricted" >> /etc/apt/sources.list
   sudo apt update
   sudo apt install enchant -y
+  sudo apt install python2 -y || true
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew upgrade python
   $PYTHON -m pip install virtualenv


### PR DESCRIPTION
Small follow-up to #634, #635, #637.

This is needed only on Focal+ where python2 is not installed by default (and we run tests which depend on it being available), but because a `python2` package doesn't exist in the earlier versions, the install of it needs to be allowed to fail.