### PR TITLE
Add note for ROS environments that target Python3

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -27,6 +27,15 @@ Once you have added that repository, run these commands to install ``catkin_tool
 
     $ sudo apt-get update
     $ sudo apt-get install python-catkin-tools
+    
+.. note::
+
+    If you are on Noetic or any ROS distribution that targets Python3, instead use:
+    
+    .. code-block:: bash
+
+        $ sudo apt-get install python3-osrf-pycommon python3-catkin-tools
+
 
 Installing on other platforms with pip
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The standard install command for `catkin_tools` does not work on distributions like Noetic, since it relies on Python2 dependencies.

This PR adds a note in the setup instructions to cover that case.