### PR TITLE
Abort with error message on circular dependency.

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -86,9 +86,15 @@ def determine_packages_to_be_built(packages, context, workspace_packages):
     ordered_packages = topological_order_packages(workspace_packages)
     # Set the packages in the workspace for the context
     context.packages = ordered_packages
-    # Determin the packages which should be built
+    # Determine the packages which should be built
     packages_to_be_built = []
     packages_to_be_built_deps = []
+
+    # Check if topological_order_packages determined any circular dependencies, if so print an error and fail.
+    # If this is the case, the last entry of ordered packages is a tuple that starts with nil.
+    if ordered_packages and ordered_packages[-1][0] is None:
+        guilty_packages = ", ".join(ordered_packages[-1][1:])
+        sys.exit("[build] Circular dependency detected in the following packages: {}".format(guilty_packages))
 
     workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
     # Determine the packages to be built


### PR DESCRIPTION
Currently, when building a workspace with circular dependencies `catkin build` crashes with a backtrace and provides no useful information. Given three packages that are circular;
```
packageA, depends on packageB
packageB, depends on packageC
packageC, depends on packageA
```

Output from the current version is:
```
[build] Found '3' packages in 0.0 seconds.                                     
Traceback (most recent call last):
<snip>
  File "<snip>verbs/catkin_build/build.py", line 94, in determine_packages_to_be_built
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
  File "<snip>verbs/catkin_build/build.py", line 94, in <listcomp>
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
AttributeError: 'str' object has no attribute 'name'
```

Catkin does have all the necessary information to help the user resolve the issue. The `topological_order_packages` function provides the [info](https://github.com/ros-infrastructure/catkin_pkg/blob/master/src/catkin_pkg/topological_order.py#L166-L167) we need, stating that if a circular depedency exist, the last tuple in the list starts with `None` and contains a superset of the guilty packages. In the three package example the `ordered_packages` variable will hold `[(None, 'packageA, packageB, packageC')]
`.

With the change in this PR, the output instead becomes:
```
[build] Found '3' packages in 0.0 seconds.                                                                                                                                                                        
[build] Circular dependency detected in the following packages: packageA, packageB, packageC
```
and the `catkin build` command exits with `1`. This provides a clear message that helps the user resolve the issue.

FYI @mikepurvis , @jasonimercer 