### PR TITLE
Fail build if jobs were abandoned

### DIFF
--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -360,7 +360,7 @@ async def execute_jobs(
         completed=completed_jobs
     ))
 
-    return all(completed_jobs.values())
+    return all(completed_jobs.values()) and len(abandoned_jobs) == 0
 
 
 def run_until_complete(coroutine):


### PR DESCRIPTION
fixes #371 

If there are valid use cases for continuing with the installation after jobs were abandoned, I can also turn this into an option. If so, please indicate if that should be on by default or off