### PR TITLE
fix `catkin locate` for symlinked package src directories

### DIFF
--- a/catkin_tools/verbs/catkin_locate/cli.py
+++ b/catkin_tools/verbs/catkin_locate/cli.py
@@ -106,7 +106,7 @@ def main(opts):
         sys.exit(0)
 
     # Get the workspace (either the given directory or the enclosing ws)
-    workspace_hint = opts_vars.get('workspace', None) or os.getcwd()
+    workspace_hint = opts_vars.get('workspace', None) or getcwd()
     workspace = find_enclosing_workspace(workspace_hint)
 
     if not workspace:
@@ -174,7 +174,7 @@ def main(opts):
 
     # Make the path relative if desired
     if opts.relative:
-        path = os.path.relpath(path, os.getcwd())
+        path = os.path.relpath(path, getcwd())
 
     # Print the path
     print(path)


### PR DESCRIPTION
In some places in `catkin locate`, `os.getcwd()` was used instead of `catkin_tools.common.getcwd()`. Therefore, `catkin locate` did not work for workspaces where packages are symlinked into the `src` directory.