### PR TITLE
Fix stdeb for python 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package catkin_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2020-06-03)
+------------------
+* This release restores the 0.4.5 state due to an accident with the 0.5.0 release where we pushed it to Python2 users which it doesn't support.
+
 0.5.0 (2020-06-02)
 ------------------
 * Revert "jobs: Fixing environment required to run catkin test targets on pre-indigo catkin" (`#600 <https://github.com/catkin/catkin_tools/issues/600>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,45 @@
 Changelog for package catkin_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.0 (2021-03-01)
+------------------
+* Fix placeholders for cmake warning and error coloring (#678)
+* Fix catkin clean --all-profiles when not at workspace root (#673)
+* Fix `catkin create pkg` without license parameter (#671) 
+* Support building from a symlinked workspace (#669)
+* Use loadavg over the last 1 minute (#668)
+* Fix shell completion install locations (#652)
+* Fix blank lines in build output (#666)
+* Use standard python function to determine terminal width (#653)
+* Fix handling of invalid package.xml files (#660)
+* Fixes for extending profiles (#658)
+* escape whitespaces in `catkin config` printout (#657)
+* updates to zsh completion (#609)
+* Ignore catkin_tools_prebuild package in build space (#650)
+* fix 'catkin locate' for symlinked pkgs inside workspace (#624)
+* Report circular dependencies detected by topological_order_packages() (#617)
+* Add `--this` option to `clean` verb (#623)
+* In catkin build, preserve original job list topological ordering (#626)
+* Fail build if jobs were abandoned (#644)
+* Fix installation of new cmake files (#615)
+* Abort with error message on circular dependency. (#641)
+* Changed yield from lock to await for Python 3.9 compat (#635)
+* Remove older py35+xenial config and add py39+focal (#637)
+* Install python2 before travis runs on Focal. (#639)
+* Bump cmake min ver to 2.8.12 (#634)
+* Fix byte decoding for python 3 (Issue #625) (#627)
+* Cleanup of jobs flag parsing (#610, #656, #655)
+* Fix get_python_install_dir for Python 2/3 (#601)
+* Minor cleanup:
+  - import cleanup (#651)
+  - remove hack (#659)
+  - Add missing space in devel layout error message
+  - fix TypeError on executing catkin env (#649)
+  - Put a space between 'workspace' and 'and' (#619)
+  - Remove redundant 'configuration' in mechanics.rst (#646)
+  - Use PYTHONASYNCIODEBUG instead of TROLLIUSDEBUG (#661)
+* Contributors: Akash Patel, Guglielmo Gemignani, Ivor Wanders, Kevin Jaget, Lucas Walter, Mathias Lüdtke, Matthijs van der Burgh, Mike Purvis, Robert Haschke, Simon Schmeisser, Tim Rakowski, Timon Engelke, Vojtech Spurny, ckurtz22, mobangjack, pseyfert, xiaxi, zig-for
+
 0.6.0 (2020-06-03)
 ------------------
 * This release restores the 0.4.5 state due to an accident with the 0.5.0 release where we pushed it to Python2 users which it doesn't support.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package catkin_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.1 (2021-07-17)
+------------------
+* Fixes in the build system requiring a version increase
+
 0.7.0 (2021-03-01)
 ------------------
 * Fix placeholders for cmake warning and error coloring (#678)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.install import install
 
 # Setup installation dependencies
 install_requires = [
-    'catkin-pkg > 0.2.9',
+    'catkin-pkg-modules',
     'setuptools',
     'PyYAML',
     'osrf-pycommon > 0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class PermissiveInstall(install):
 
 setup(
     name='catkin_tools',
-    version='0.6.0',
+    version='0.7.0',
     python_requires='>=3.5',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,15 @@ from setuptools.command.install import install
 
 # Setup installation dependencies
 install_requires = [
-    'catkin-pkg >= 0.3.0',
     'setuptools',
     'PyYAML',
     'osrf-pycommon > 0.1.1',
 ]
+
+# When building the deb, do not require catkin_pkg
+if 'DEB_BUILD' not in os.environ:
+    install_requires += ['catkin_pkg >= 0.3.0']
+
 
 # Figure out the resources that need to be installed
 this_dir = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class PermissiveInstall(install):
 
 setup(
     name='catkin_tools',
-    version='0.5.0',
+    version='0.6.0',
     python_requires='>=3.5',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.install import install
 
 # Setup installation dependencies
 install_requires = [
-    'catkin-pkg-modules',
+    'catkin-pkg >= 0.3.0',
     'setuptools',
     'PyYAML',
     'osrf-pycommon > 0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class PermissiveInstall(install):
 
 setup(
     name='catkin_tools',
-    version='0.7.0',
+    version='0.7.1',
     python_requires='>=3.5',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,5 @@
 [DEFAULT]
-Depends: python-argparse, python-setuptools, python-catkin-pkg (> 0.2.9), python-yaml
-Depends3: python3-setuptools, python3-catkin-pkg (> 0.2.9), python3-yaml
-Conflicts: python3-catkin-tools
+Depends3: python3-setuptools, python3-catkin-pkg-modules, python3-yaml, python3-osrf-pycommon
 Conflicts3: python-catkin-tools
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,3 +4,4 @@ Conflicts3: python-catkin-tools
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5
 Setup-Env-Vars: DEB_BUILD=1
+No-Python2:


### PR DESCRIPTION
This is my attempt to fix #594. The following changes are done:

- replace dependency catkin-pkg with catkin-pkg-modules (`> 0.2.9` can be dropped because catkin-pkg-modules was introduced with 0.3.0)
- `Depends` and `Conflicts` (i. e., the python 2 settings) were removed from `stdeb.cfg` because no further python 2 packages will be built.
- `python3-osrf-pycommon` was added as a deb dependency (I don't know why it was missing)

I tested the changes on five different systems:

- Debian 9 Stretch (python 3.5.3)
- Debian 10 Buster (python 3.7.3)
- Ubuntu 16.04 Xenial Xerus (python 3.5.2)
- Ubuntu 18.04 Bionic Beaver (python 3.6.9)
- Ubuntu 20.04 Focal Fossa (python 3.8.5)

Once all build dependencies were installed, I used the command `python3 setup.py --command-packages=stdeb.command sdist_dsc --with-python2=False bdist_deb` to create the deb file. It could be installed on all systems and catkin commands could be executed without error.
The mentioned systems cover all the systems in `Suite`, assuming that the non-LTS Ubuntu releases behave like either the predecessor or the successor.

Before the release with these changes, the trivial fix in https://github.com/osrf/osrf_pycommon/pull/71 should be merged. Currently, `python3-osrf-pycommon` and `python-osrf-pycommon` don't conflict in all cases, resulting in annoying apt errors on installing  `python3-osrf-pycommon` when `python-osrf-pycommon` was already installed.

Before the release, the version in `setup.py` an the changelog should obviously be updated.