### PR TITLE
Fix TypeError on executing catkin env

### DIFF
--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -23,17 +23,7 @@ from fnmatch import fnmatch
 
 import asyncio
 
-from shlex import split as _cmd_split
-try:
-    _cmd_split(u'\u00E9')
-
-    def cmd_split(s):
-        if sys.version_info.major == 3:
-            return _cmd_split(str(s, 'utf-8'))
-        else:
-            return _cmd_split(s.decode('utf-8'))
-except UnicodeEncodeError:
-    cmd_split = _cmd_split
+from shlex import split as cmd_split
 
 try:
     from shlex import quote as cmd_quote
@@ -675,7 +665,7 @@ def parse_env_str(environ_str):
     """
 
     try:
-        split_envs = [e.split('=', 1) for e in cmd_split(environ_str)]
+        split_envs = [e.split('=', 1) for e in cmd_split(environ_str.decode())]
         return {
             e[0]: e[1] for e
             in split_envs

--- a/catkin_tools/verbs/catkin_env/cli.py
+++ b/catkin_tools/verbs/catkin_env/cli.py
@@ -105,8 +105,7 @@ def main(opts):
     # Update environment from stdin
     if opts.stdin:
         input_env_str = sys.stdin.read()
-
-        environ.update(parse_env_str(input_env_str))
+        environ.update(parse_env_str(input_env_str.encode()))
 
     # Finally, update with explicit vars
     environ.update(opts.envs)
@@ -121,7 +120,7 @@ def main(opts):
                 if isinstance(ret, int):
                     return ret
                 else:
-                    print(ret, end='')
+                    print(ret.decode(), end='')
 
     # Flush stdout
     # NOTE: This is done to ensure that automated use of this tool doesn't miss


### PR DESCRIPTION
Currently, when executing `catkin env`, a `TypeError` is raised. This pull request fixes the behavior by calling `encode` before `cmd_split` and `decode` afterwards. Also, the current wrapper around `shlex.split` is no longer needed with python 3.