### PR TITLE
Ignore catkin_tools_prebuild package in build space

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -68,6 +68,11 @@ def get_prebuild_package(build_space_abs, devel_space_abs, force):
         with open(package_xml_path, 'wb') as package_xml:
             package_xml.write(SETUP_PREBUILD_PACKAGE_XML_TEMPLATE.encode('utf-8'))
 
+    # Create CATKIN_IGNORE file because this package should not be found by catkin
+    # This is only necessary when the build space is inside of the source space
+    catkin_ignore_path = os.path.join(prebuild_path, 'CATKIN_IGNORE')
+    open(catkin_ignore_path, 'wb').close()
+
     # Create the build directory for this package
     mkdir_p(os.path.join(build_space_abs, 'catkin_tools_prebuild'))
 

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -60,6 +60,7 @@ from .color import clr
 
 
 BUILDSPACE_MARKER_FILE = '.catkin_tools.yaml'
+BUILDSPACE_IGNORE_FILE = 'CATKIN_IGNORE'
 DEVELSPACE_MARKER_FILE = '.catkin_tools.yaml'
 
 


### PR DESCRIPTION
This adds a `CATKIN_IGNORE` file to `build/catkin_tools_prebuild`. This is necessary when the build space is a subdirectory of the source space. Without this patch, the `package.xml` file in `build/catkin_tools_prebuild` is found by `catkin_pkg` when searching all packages in the source space, resulting in the strange behavior described in #621.