### PR TITLE
Import cleanup

### DIFF
--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
-from datetime import date
 import os
 import pkg_resources
 import sys
-
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote
+from datetime import date
+from shlex import quote as cmd_quote
 
 from catkin_tools.common import is_tty
 

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -12,23 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
+import asyncio
 import datetime
 import errno
 import os
 import re
 import sys
 from fnmatch import fnmatch
-
-import asyncio
-
 from shlex import split as cmd_split
-
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote
+from shlex import quote as cmd_quote
 
 from catkin_pkg.packages import find_packages
 

--- a/catkin_tools/config.py
+++ b/catkin_tools/config.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import yaml
-import shlex
+from shlex import split as cmd_split
 
 from .common import string_type
 
@@ -104,7 +102,7 @@ def get_verb_aliases(path=catkin_config_path):
                 parsed_value = None
                 if isinstance(value, string_type):
                     # Parse using shlex
-                    parsed_value = shlex.split(value)
+                    parsed_value = cmd_split(value)
                 elif isinstance(value, list) or isinstance(value, type(None)):
                     # Take plainly
                     parsed_value = value

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -14,8 +14,6 @@
 
 """This module implements a class for representing a catkin workspace context"""
 
-from __future__ import print_function
-
 import os
 import re
 import sys

--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    # Python3
-    from queue import Empty
-except ImportError:
-    # Python2
-    from Queue import Empty
-
 import math
 import itertools
 import sys
 import threading
 import time
+from queue import Empty
 
 from catkin_tools.common import disable_wide_log
 from catkin_tools.common import format_time_delta

--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-import traceback
-
-from itertools import tee
-
 import asyncio
-
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import FIRST_COMPLETED
-
+from itertools import tee
 from osrf_pycommon.process_utils import async_execute_process
 from osrf_pycommon.process_utils import get_loop
 

--- a/catkin_tools/execution/io.py
+++ b/catkin_tools/execution/io.py
@@ -14,9 +14,7 @@
 
 import os
 import shutil
-
 from glob import glob
-
 from osrf_pycommon.process_utils import AsyncSubprocessProtocol
 
 from catkin_tools.common import mkdir_p

--- a/catkin_tools/execution/job_server.py
+++ b/catkin_tools/execution/job_server.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-from multiprocessing import cpu_count
-from tempfile import mkstemp
-from termios import FIONREAD
-
 import array
 import fcntl
 import os
 import re
 import subprocess
 import time
+from multiprocessing import cpu_count
+from tempfile import mkstemp
+from termios import FIONREAD
 
 from catkin_tools.common import log
 from catkin_tools.common import version_tuple

--- a/catkin_tools/execution/jobs.py
+++ b/catkin_tools/execution/jobs.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 from catkin_tools.terminal_color import ColorMapper
 
 mapper = ColorMapper()

--- a/catkin_tools/execution/stages.py
+++ b/catkin_tools/execution/stages.py
@@ -14,13 +14,9 @@
 
 import os
 import traceback
+from shlex import quote as cmd_quote
 
 from catkin_tools.common import string_type
-
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote
 
 from .io import IOBufferLogger
 from .io import IOBufferProtocol

--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -14,11 +14,7 @@
 
 import csv
 import os
-
-try:
-    from md5 import md5
-except ImportError:
-    from hashlib import md5
+from hashlib import md5
 
 from catkin_tools.argument_parsing import handle_make_arguments
 

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -45,13 +45,6 @@ from catkin_tools.terminal_color import ColorMapper
 mapper = ColorMapper()
 clr = mapper.clr
 
-# FileNotFoundError from Python3
-try:
-    FileNotFoundError
-except NameError:
-    class FileNotFoundError(OSError):
-        pass
-
 
 def copy_install_manifest(
         logger, event_queue,

--- a/catkin_tools/jobs/commands/cmake.py
+++ b/catkin_tools/jobs/commands/cmake.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import re
 

--- a/catkin_tools/jobs/output.py
+++ b/catkin_tools/jobs/output.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 
 from catkin_tools.terminal_color import ansi

--- a/catkin_tools/jobs/utils.py
+++ b/catkin_tools/jobs/utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import pkg_resources
 import shutil

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-try:
-    from md5 import md5
-except ImportError:
-    from hashlib import md5
 import os
 import subprocess
 import sys
-
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote
-
+from hashlib import md5
 from osrf_pycommon.process_utils import execute_process
+from shlex import quote as cmd_quote
 
 from .common import parse_env_str
 from .common import string_type

--- a/catkin_tools/terminal_color.py
+++ b/catkin_tools/terminal_color.py
@@ -16,8 +16,6 @@
 Module to enable color terminal output
 """
 
-from __future__ import print_function
-
 import string
 import os
 

--- a/catkin_tools/utils.py
+++ b/catkin_tools/utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 
 

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -16,19 +16,13 @@
 
 import os
 import pkg_resources
+from queue import Queue
 import sys
 import time
 import traceback
 import yaml
-
 import asyncio
 
-try:
-    # Python3
-    from queue import Queue
-except ImportError:
-    # Python2
-    from Queue import Queue
 
 try:
     from catkin_pkg.packages import find_packages

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import logging
 import os

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -18,13 +18,8 @@ import pkg_resources
 import sys
 import time
 import traceback
+from queue import Queue
 
-try:
-    # Python3
-    from queue import Queue
-except ImportError:
-    # Python2
-    from Queue import Queue
 
 try:
     from catkin_pkg.packages import find_packages

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-try:
-    raw_input
-except NameError:
-    raw_input = input
-
 import os
 import shutil
 import sys
@@ -59,7 +52,7 @@ setup_files = ['.catkin', 'env.sh', 'setup.bash', 'setup.sh', 'setup.zsh', '_set
 
 def yes_no_loop(question):
     while True:
-        resp = str(raw_input(question + " [yN]: "))
+        resp = str(input(question + " [yN]: "))
         if resp.lower() in ['n', 'no'] or len(resp) == 0:
             return False
         elif resp.lower() in ['y', 'yes']:

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 
 from catkin_tools.argument_parsing import add_cmake_and_make_and_catkin_make_args

--- a/catkin_tools/verbs/catkin_create/cli.py
+++ b/catkin_tools/verbs/catkin_create/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 
 from catkin_tools.argument_parsing import add_context_args

--- a/catkin_tools/verbs/catkin_env/cli.py
+++ b/catkin_tools/verbs/catkin_env/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import re
 import sys

--- a/catkin_tools/verbs/catkin_init/cli.py
+++ b/catkin_tools/verbs/catkin_init/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 
 from catkin_tools.argument_parsing import add_workspace_arg

--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import sys
 
 from catkin_tools.argument_parsing import add_context_args

--- a/catkin_tools/verbs/catkin_locate/cli.py
+++ b/catkin_tools/verbs/catkin_locate/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 from catkin_tools.context import Context
 
 from catkin_tools.metadata import get_active_profile

--- a/tests/system/verbs/catkin_build/test_args.py
+++ b/tests/system/verbs/catkin_build/test_args.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/tests/system/verbs/catkin_build/test_build.py
+++ b/tests/system/verbs/catkin_build/test_build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 import shutil

--- a/tests/system/verbs/catkin_build/test_bwlists.py
+++ b/tests/system/verbs/catkin_build/test_bwlists.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/system/verbs/catkin_build/test_context.py
+++ b/tests/system/verbs/catkin_build/test_context.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/system/verbs/catkin_build/test_eclipse.py
+++ b/tests/system/verbs/catkin_build/test_eclipse.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 from ....utils import in_temporary_directory

--- a/tests/system/verbs/catkin_build/test_modify_ws.py
+++ b/tests/system/verbs/catkin_build/test_modify_ws.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/system/verbs/catkin_build/test_unit_tests.py
+++ b/tests/system/verbs/catkin_build/test_unit_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,11 +1,6 @@
-try:
-    # Python3
-    from queue import Queue
-except ImportError:
-    # Python2
-    from Queue import Queue
-
 import binascii
+from queue import Queue
+
 from catkin_tools.execution import io as io
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,28 +1,15 @@
-from __future__ import print_function
-
 import functools
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
-
-import subprocess
+from io import StringIO
+from subprocess import TimeoutExpired
 
 from catkin_tools.commands.catkin import main as catkin_main
 
-try:
-    # Python2
-    from StringIO import StringIO
-except ImportError:
-    # Python3
-    from io import StringIO
-
-try:
-    from subprocess import TimeoutExpired
-except ImportError:
-    class TimeoutExpired(object):
-        pass
 
 TESTS_DIR = os.path.dirname(__file__)
 MOCK_DIR = os.path.join(TESTS_DIR, 'mock_resources')

--- a/tests/workspace_assertions.py
+++ b/tests/workspace_assertions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 import yaml


### PR DESCRIPTION
This pull request removes conditional imports that work in python 2 and python 3 in favor of the python 3 version and removes all `__future__` imports. Also, some imports were resorted.