### PR TITLE
escape whitespaces in `catkin config` printout

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -578,6 +578,9 @@ class Context(object):
             install_layout = 'merged' if not self.__isolate_install else 'isolated'
 
         def quote(argument):
+            # Distinguish in the printout if space separates two arguments or if we
+            # print an argument with a space.
+            # e.g. -DCMAKE_C_FLAGS="-g -O3" -DCMAKE_C_COMPILER=clang
             if ' ' in argument:
                 if "=" in argument:
                     key, value = argument.split("=", 1)

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -579,8 +579,11 @@ class Context(object):
 
         def quote(argument):
             if ' ' in argument:
-                key, value = argument.split("=")
-                return key + '="' + value + '"'
+                if "=" in argument:
+                    key, value = argument.split("=", 1)
+                    if ' ' not in key:
+                        return key + '="' + value + '"'
+                return '"' + argument + '"'
             return argument
 
         subs = {

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -577,13 +577,19 @@ class Context(object):
         if self.__install:
             install_layout = 'merged' if not self.__isolate_install else 'isolated'
 
+        def quote(argument):
+            if ' ' in argument:
+                key, value = argument.split("=")
+                return key + '="' + value + '"'
+            return argument
+
         subs = {
             'profile': self.profile,
             'extend_mode': extend_mode,
             'extend': extend_value,
             'install_layout': install_layout,
             'cmake_prefix_path': (self.cmake_prefix_path or ['Empty']),
-            'cmake_args': ' '.join([a.replace(" ", "\\ ") for a in self.__cmake_args or ['None']]),
+            'cmake_args': ' '.join([quote(a) for a in self.__cmake_args or ['None']]),
             'make_args': ' '.join(self.__make_args + self.__jobs_args or ['None']),
             'catkin_make_args': ', '.join(self.__catkin_make_args or ['None']),
             'source_missing': existence_str(self.source_space_abs),

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -583,7 +583,7 @@ class Context(object):
             'extend': extend_value,
             'install_layout': install_layout,
             'cmake_prefix_path': (self.cmake_prefix_path or ['Empty']),
-            'cmake_args': ' '.join(self.__cmake_args or ['None']),
+            'cmake_args': ' '.join([a.replace(" ", "\\ ") for a in self.__cmake_args or ['None']]),
             'make_args': ' '.join(self.__make_args + self.__jobs_args or ['None']),
             'catkin_make_args': ', '.join(self.__catkin_make_args or ['None']),
             'source_missing': existence_str(self.source_space_abs),


### PR DESCRIPTION
In the `catkin config` printout, the cmake-args line changes from
```
Additional CMake Args:       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS=-g -fno-omit-frame-pointer -O3 -DNDEBUG -DENABLE_TIMING=0
```
to
```
Additional CMake Args:       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS=-g\ -fno-omit-frame-pointer\ -O3\ -DNDEBUG -DENABLE_TIMING=0
```
thereby the printout can be copy and pasted to `catkin config
--cmake-args` without changing the configuration. In the above example
the last element `-DENABLE_TIMING` is a cmake option and not a
gcc preprocessor definition. Before this patch, this is
indistinguishable from the printout.

I did not thoroughly check which of the other entries in the printout might have whitespaces that deserve escaping - cmake-args is the only one where it occurs to me.