### PR TITLE
Fixes for extending profiles

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -264,7 +264,7 @@ class Context(object):
                 files[file] = {key: value}
 
         for key, val in data.items():
-            if key in context.key_origins:
+            if context.extends is not None and key in context.key_origins:
                 save_in_file(context.key_origins[key], key, val)
             else:
                 save_in_file(context.profile, key, val)

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -62,6 +62,8 @@ def prepare_arguments(parser):
         help="Copy the settings from an existing profile. (default: None)")
     add('--copy-active', action='store_true', default=False,
         help="Copy the settings from the active profile.")
+    add('--extend', metavar='PARENT_PROFILE', type=str,
+        help="Extend another profile")
 
     add = parser_rename.add_argument
     add('current_name', type=str,
@@ -146,6 +148,12 @@ def main(opts):
                               'based on profile @{cf}%s@|' % (opts.name, opts.copy)))
                 else:
                     print(clr('[profile] @{rf}A profile with this name does not exist: %s@|' % opts.copy))
+            elif opts.extend:
+                if opts.extend in profiles:
+                    new_ctx = Context(workspace=ctx.workspace, profile=opts.name, extends=opts.extend)
+                    Context.save(new_ctx)
+                    print(clr('[profile] Created a new profile named @{cf}%s@| '
+                              'extending profile @{cf}%s@|' % (opts.name, opts.extend)))
             else:
                 new_ctx = Context(workspace=ctx.workspace, profile=opts.name)
                 Context.save(new_ctx)

--- a/tests/system/verbs/catkin_profile/test_profile.py
+++ b/tests/system/verbs/catkin_profile/test_profile.py
@@ -1,11 +1,10 @@
 import os
 
+from ...workspace_factory import workspace_factory
 from ....utils import in_temporary_directory
 from ....utils import assert_cmd_success
 
-from ....workspace_assertions import assert_workspace_initialized
-from ....workspace_assertions import assert_warning_message
-from ....workspace_assertions import assert_no_warnings
+from ....workspace_assertions import assert_in_config
 
 
 @in_temporary_directory
@@ -22,3 +21,11 @@ def test_profile_set():
     assert_cmd_success(['catkin', 'init'])
     assert_cmd_success(['catkin', 'build'])
     assert_cmd_success(['catkin', 'profile', 'set', 'default'])
+
+
+def test_profile_copy():
+    with workspace_factory() as wf:
+        wf.build()
+        assert_cmd_success(['catkin', 'config', '--make-args', 'test'])
+        assert_cmd_success(['catkin', 'profile', 'add', '--copy', 'default', 'mycopy'])
+        assert_in_config('.', 'mycopy', 'make_args', ['test'])

--- a/tests/system/verbs/catkin_profile/test_profile.py
+++ b/tests/system/verbs/catkin_profile/test_profile.py
@@ -29,3 +29,13 @@ def test_profile_copy():
         assert_cmd_success(['catkin', 'config', '--make-args', 'test'])
         assert_cmd_success(['catkin', 'profile', 'add', '--copy', 'default', 'mycopy'])
         assert_in_config('.', 'mycopy', 'make_args', ['test'])
+
+
+def test_profile_extend():
+    with workspace_factory() as wf:
+        wf.build()
+        assert_cmd_success(['catkin', 'config', '--make-args', 'test'])
+        assert_cmd_success(['catkin', 'profile', 'add', '--extend', 'default', 'myextend'])
+        assert_cmd_success(['catkin', 'config', '--profile', 'myextend', '--blacklist', 'mypackage'])
+        assert_in_config('.', 'default', 'make_args', ['test'])
+        assert_in_config('.', 'myextend', 'blacklist', ['mypackage'])


### PR DESCRIPTION
This fixes a regression introduced in #592 that stopped `catkin profile add --copy` from working (#607). Additionally, a command line argument `--extend` for the functionality in #592 and two tests have been added.