### PR TITLE
Remove hack from a478190

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -62,32 +62,6 @@ from .build import build_isolated_workspace
 from .build import determine_packages_to_be_built
 from .build import verify_start_with_option
 
-#
-# Begin Hack
-#
-
-# TODO(wjwwood): remove this, once it is no longer needed.
-# argparse may not support mutually exclusive groups inside other groups, see:
-#   http://bugs.python.org/issue10680
-
-# Backup the original constructor
-backup__ArgumentGroup___init__ = argparse._ArgumentGroup.__init__
-
-
-# Make a new constructor with the fix
-def fixed__ArgumentGroup___init__(self, container, title=None, description=None, **kwargs):
-    backup__ArgumentGroup___init__(self, container, title, description, **kwargs)
-    # Make sure this line is run, maybe redundant on versions which already have it
-    self._mutually_exclusive_groups = container._mutually_exclusive_groups
-
-
-# Monkey patch in the fixed constructor
-argparse._ArgumentGroup.__init__ = fixed__ArgumentGroup___init__
-
-#
-# End Hack
-#
-
 
 def prepare_arguments(parser):
     parser.description = """\


### PR DESCRIPTION
A hack for https://bugs.python.org/issue10680 was introduced in a478190faec7d88565d056458fce285d19d23a75. The bug was fixed in Python 2.7 / 3.2, so we no longer need the hack.