### PR TITLE
Fix handling of invalid package.xml

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -229,15 +229,16 @@ def main(opts):
         # Determine the enclosing package
         try:
             ws_path = find_enclosing_workspace(getcwd())
-            # Suppress warnings since this won't necessaraly find all packages
+            # Suppress warnings since this won't necessarily find all packages
             # in the workspace (it stops when it finds one package), and
             # relying on it for warnings could mislead people.
             this_package = find_enclosing_package(
                 search_start_path=getcwd(),
                 ws_path=ws_path,
                 warnings=[])
-        except (InvalidPackage, RuntimeError):
-            this_package = None
+        except InvalidPackage as ex:
+            sys.exit(clr("@{rf}Error:@| The file %s is an invalid package.xml file."
+                         " See below for details:\n\n%s" % (ex.package_path, ex.msg)))
 
         # Handle context-based package building
         if opts.build_this:

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -313,8 +313,9 @@ def clean_profile(opts, profile):
                         search_start_path=getcwd(),
                         ws_path=ws_path,
                         warnings=[])
-                except (InvalidPackage, RuntimeError):
-                    this_package = None
+                except InvalidPackage as ex:
+                    sys.exit(clr("@{rf}Error:@| The file %s is an invalid package.xml file."
+                                 " See below for details:\n\n%s" % (ex.package_path, ex.msg)))
 
                 # Handle context-based package cleaning
                 if opts.clean_this:

--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -75,8 +75,7 @@ def main(opts):
     ctx = Context.load(opts.workspace, opts.profile, load_env=False)
 
     if not ctx:
-        print(clr("@{rf}ERROR: Could not determine workspace.@|"), file=sys.stderr)
-        sys.exit(1)
+        sys.exit(clr("@{rf}ERROR: Could not determine workspace.@|"), file=sys.stderr)
 
     if opts.directory:
         folders = opts.directory
@@ -92,9 +91,8 @@ def main(opts):
             packages = find_packages(folder, warnings=warnings)
             ordered_packages = topological_order_packages(packages)
             if ordered_packages and ordered_packages[-1][0] is None:
-                print(clr("@{rf}ERROR: Circular dependency within packages:@| "
-                          + ordered_packages[-1][1]), file=sys.stderr)
-                sys.exit(1)
+                sys.exit(clr("@{rf}ERROR: Circular dependency within packages:@| "
+                             + ordered_packages[-1][1]), file=sys.stderr)
             packages_by_name = {pkg.name: (pth, pkg) for pth, pkg in ordered_packages}
 
             if opts.depends_on or opts.rdepends_on:
@@ -152,9 +150,8 @@ def main(opts):
                         for dep in run_deps:
                             print(clr('  @{pf}-@| %s' % dep.name))
         except InvalidPackage as ex:
-            message = '\n'.join(ex.args)
-            print(clr("@{rf}Error:@| The directory %s contains an invalid package."
-                      " See below for details:\n\n%s" % (folder, message)))
+            sys.exit(clr("@{rf}Error:@| The file %s is an invalid package.xml file."
+                         " See below for details:\n\n%s" % (ex.package_path, ex.msg)))
 
     # Print out warnings
     if not opts.quiet:


### PR DESCRIPTION
This pull request fixes the handling of invalid `package.xml` files so that instead of printing the raw exception, a proper error message is printed. Also, the pattern `print` with `sys.exit` is replaced with `sys.exit(string)`.
It closes #287.