### PR TITLE
Use PYTHONASYNCIODEBUG instead of TROLLIUSDEBUG

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -214,7 +214,7 @@ def main(opts):
 
     # Check for develdebug mode
     if opts.develdebug is not None:
-        os.environ['TROLLIUSDEBUG'] = opts.develdebug.lower()
+        os.environ['PYTHONASYNCIODEBUG'] = opts.develdebug.lower()
         logging.basicConfig(level=opts.develdebug.upper())
 
     # Set color options


### PR DESCRIPTION
When building with `--develdebug`, the environment variable `PYTHONASYNCIODEBUG` should be used instead of `TROLLIUSDEBUG`.