### PR TITLE
Evaluate conditional dependencies in package.xml

### DIFF
--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -30,16 +30,6 @@ from .terminal_color import ColorMapper
 color_mapper = ColorMapper()
 clr = color_mapper.clr
 
-try:
-    string_type = basestring
-except NameError:
-    string_type = str
-
-try:
-    unicode_type = unicode
-except NameError:
-    unicode_type = str
-
 
 class FakeLock(asyncio.locks.Lock):
 
@@ -48,9 +38,8 @@ class FakeLock(asyncio.locks.Lock):
     def locked(self):
         return False
 
-    @asyncio.coroutine
-    def acquire(self):
-        return(True)
+    async def acquire(self):
+        return True
 
     def release(self):
         pass
@@ -178,18 +167,15 @@ def get_cached_recursive_build_depends_in_workspace(package, workspace_packages)
 def get_recursive_depends_in_workspace(
         packages,
         ordered_packages,
-        root_include_function,
         include_function,
         exclude_function):
     """Computes the recursive dependencies of a package in a workspace based on
     include and exclude functions of each package's dependencies.
 
-    :param package: package for which the recursive depends should be calculated
-    :type package: :py:class:`catkin_pkg.package.Package`
+    :param packages: package for which the recursive depends should be calculated
+    :type packages: list(:py:class:`catkin_pkg.package.Package`)
     :param ordered_packages: packages in the workspace, ordered topologically
     :type ordered_packages: list(tuple(package path, :py:class:`catkin_pkg.package.Package`))
-    :param root_include_function: a function which take a package and returns a list of root packages to include
-    :type root_include_function: callable
     :param include_function: a function which take a package and returns a list of packages to include
     :type include_function: callable
     :param exclude_function: a function which take a package and returns a list of packages to exclude
@@ -208,11 +194,11 @@ def get_recursive_depends_in_workspace(
     }
 
     # Initialize working sets
-    pkgs_to_check = set([
+    pkgs_to_check = set(
         pkg.name
         # Only include the packages where the condition has evaluated to true
-        for pkg in chain(*(filter(lambda pkg: pkg.evaluated_condition, root_include_function(p)) for p in packages))
-    ])
+        for pkg in chain(*(filter(lambda pkg: pkg.evaluated_condition, include_function(p)) for p in packages))
+    )
 
     checked_pkgs = set()
     recursive_deps = set()
@@ -225,16 +211,16 @@ def get_recursive_depends_in_workspace(
             continue
         # Add this package's dependencies which should be checked
         _, pkg = workspace_packages_by_name[pkg_name]
-        pkgs_to_check.update([
+        pkgs_to_check.update(
             d.name
             for d in filter(lambda pkg: pkg.evaluated_condition, include_function(pkg))
             if d.name not in checked_pkgs
-        ])
+        )
         # Add this package's dependencies which shouldn't be checked
-        checked_pkgs.update([
+        checked_pkgs.update(
             d.name
             for d in exclude_function(pkg)
-        ])
+        )
         # Add the package itself in case we have a circular dependency
         checked_pkgs.add(pkg.name)
         # Add this package to the list of recursive dependencies for this package
@@ -266,11 +252,6 @@ def get_recursive_build_depends_in_workspace(package, ordered_packages):
     return get_recursive_depends_in_workspace(
         [package],
         ordered_packages,
-        root_include_function=lambda p: (
-            p.build_depends +
-            p.buildtool_depends +
-            p.test_depends +
-            p.run_depends),
         include_function=lambda p: (
             p.build_depends +
             p.buildtool_depends +
@@ -285,7 +266,7 @@ def get_recursive_run_depends_in_workspace(packages, ordered_packages):
     but excluding packages which are build depended on by another package in the list
 
     :param packages: packages for which the recursive depends should be calculated
-    :type packages: list of :py:class:`catkin_pkg.package.Package`
+    :type packages: list(:py:class:`catkin_pkg.package.Package`)
     :param ordered_packages: packages in the workspace, ordered topologically
     :type ordered_packages: list(tuple(package path,
         :py:class:`catkin_pkg.package.Package`))
@@ -297,7 +278,6 @@ def get_recursive_run_depends_in_workspace(packages, ordered_packages):
     return get_recursive_depends_in_workspace(
         packages,
         ordered_packages,
-        root_include_function=lambda p: p.run_depends,
         include_function=lambda p: p.run_depends,
         exclude_function=lambda p: p.buildtool_depends + p.build_depends
     )
@@ -307,8 +287,8 @@ def get_recursive_build_dependents_in_workspace(package_name, ordered_packages):
     """Calculates the recursive build dependents of a package which are also in
     the ordered_packages
 
-    :param package: package for which the recursive depends should be calculated
-    :type package: :py:class:`catkin_pkg.package.Package`
+    :param package_name: name of the package for which the recursive depends should be calculated
+    :type package_name: str
     :param ordered_packages: packages in the workspace, ordered topologically
     :type ordered_packages: list(tuple(package path,
         :py:class:`catkin_pkg.package.Package`))
@@ -336,8 +316,8 @@ def get_recursive_run_dependents_in_workspace(package_name, ordered_packages):
     """Calculates the recursive run dependents of a package which are also in
     the ordered_packages
 
-    :param package: package for which the recursive depends should be calculated
-    :type package: :py:class:`catkin_pkg.package.Package`
+    :param package_name: name of the package for which the recursive depends should be calculated
+    :type package_name: str
     :param ordered_packages: packages in the workspace, ordered topologically
     :type ordered_packages: list(tuple(package path,
         :py:class:`catkin_pkg.package.Package`))
@@ -378,7 +358,7 @@ def log(*args, **kwargs):
     except UnicodeEncodeError:
         # Strip unicode characters from string args
         sanitized_args = [unicode_sanitizer.sub('?', a)
-                          if type(a) in [str, unicode_type]
+                          if isinstance(a, str)
                           else a
                           for a in args]
         print(*sanitized_args, **kwargs)

--- a/catkin_tools/config.py
+++ b/catkin_tools/config.py
@@ -16,8 +16,6 @@ import os
 import yaml
 from shlex import split as cmd_split
 
-from .common import string_type
-
 catkin_config_path = os.path.join(os.path.expanduser('~'), '.config', 'catkin')
 
 builtin_verb_aliases_content = """\
@@ -96,11 +94,11 @@ def get_verb_aliases(path=catkin_config_path):
                 raise RuntimeError("Invalid alias file ('{0}'), expected a dict but got a {1}"
                                    .format(full_path, type(yaml_dict)))
             for key, value in yaml_dict.items():
-                if not isinstance(key, string_type):
+                if not isinstance(key, str):
                     raise RuntimeError("Invalid alias in file ('{0}'), expected a string but got '{1}' of type {2}"
                                        .format(full_path, key, type(key)))
                 parsed_value = None
-                if isinstance(value, string_type):
+                if isinstance(value, str):
                     # Parse using shlex
                     parsed_value = cmd_split(value)
                 elif isinstance(value, list) or isinstance(value, type(None)):

--- a/catkin_tools/execution/stages.py
+++ b/catkin_tools/execution/stages.py
@@ -16,8 +16,6 @@ import os
 import traceback
 from shlex import quote as cmd_quote
 
-from catkin_tools.common import string_type
-
 from .io import IOBufferLogger
 from .io import IOBufferProtocol
 
@@ -83,7 +81,7 @@ class CommandStage(Stage):
         :param logger_factory: The factory to use to construct a logger (default: IOBufferProtocol.factory)
         """
 
-        if not type(cmd) in [list, tuple] or not all([isinstance(s, string_type) for s in cmd]):
+        if not type(cmd) in [list, tuple] or not all([isinstance(s, str) for s in cmd]):
             raise ValueError('Command stage must be a list of strings: {}'.format(cmd))
         super(CommandStage, self).__init__(label, logger_factory, occupy_job, locked_resource)
 

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -20,7 +20,6 @@ from osrf_pycommon.process_utils import execute_process
 from shlex import quote as cmd_quote
 
 from .common import parse_env_str
-from .common import string_type
 
 DEFAULT_SHELL = '/bin/bash'
 
@@ -139,7 +138,7 @@ def get_resultspace_environment(result_space_path, base_env=None, quiet=False, c
             for ret in execute_process(command, cwd=os.getcwd(), env=base_env, emulate_tty=False, shell=True):
                 if type(ret) is bytes:
                     ret = ret.decode()
-                if isinstance(ret, string_type):
+                if isinstance(ret, str):
                     lines += ret
         else:
             p = subprocess.Popen(command, cwd=os.getcwd(), env=base_env, shell=True, stdout=subprocess.PIPE)

--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -137,8 +137,8 @@ def main(opts):
                     build_deps = [p for dp, p in get_recursive_build_depends_in_workspace(pkg, ordered_packages)]
                     run_deps = [p for dp, p in get_recursive_run_depends_in_workspace([pkg], ordered_packages)]
                 else:
-                    build_deps = pkg.build_depends
-                    run_deps = pkg.run_depends
+                    build_deps = [dep for dep in pkg.build_depends if dep.evaluated_condition]
+                    run_deps = [dep for dep in pkg.run_depends if dep.evaluated_condition]
 
                 if opts.deps or opts.rdeps:
                     if len(build_deps) > 0:

--- a/tests/system/resources/catkin_pkgs/depend_condition/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/depend_condition/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(build_type_condition)

--- a/tests/system/resources/catkin_pkgs/depend_condition/package.xml
+++ b/tests/system/resources/catkin_pkgs/depend_condition/package.xml
@@ -1,0 +1,11 @@
+<package format="3">
+  <name>depend_condition</name>
+  <description>Package with conditional depend element.</description>
+  <version>0.1.0</version>
+  <license>BSD</license>
+  <maintainer email="todo@todo.todo">todo</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend condition="$ROS_VERSION == 1">ros1_pkg</depend>
+  <depend condition="$ROS_VERSION == 2">ros2_pkg</depend>
+</package>

--- a/tests/system/verbs/catkin_build/test_build.py
+++ b/tests/system/verbs/catkin_build/test_build.py
@@ -378,3 +378,19 @@ def test_pkg_with_conditional_build_type():
             # So we have to infer this skipping by checking the build directory.
             msg = "Package with ROS 2 conditional build_type was skipped."
             assert os.path.exists(os.path.join('build', 'build_type_condition')), msg
+
+
+def test_pkg_with_conditional_depend():
+    """Test building a package with a condition attribute in the depend tag"""
+    with redirected_stdio() as (out, err):
+        with workspace_factory() as wf:
+            wf.create_package('ros1_pkg')
+            wf.create_package('ros2_pkg')
+            wf.build()
+            shutil.copytree(
+                os.path.join(RESOURCES_DIR, 'catkin_pkgs', 'depend_condition'),
+                os.path.join('src/depend_condition'))
+            assert catkin_success(BUILD + ['depend_condition'], env={'ROS_VERSION': '1'})
+            assert os.path.exists(os.path.join('build', 'depend_condition'))
+            assert os.path.exists(os.path.join('build', 'ros1_pkg'))
+            assert not os.path.exists(os.path.join('build', 'ros2_pkg'))

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -13,6 +13,8 @@ class MockPackage(mock.Mock):
         self.run_depends = []
         self.exec_depends = []
         self.build_export_depends = []
+        self.evaluated_condition = True
+
 
 def test_get_recursive_build_depends_in_workspace_with_test_depend():
     pkg1 = MockPackage('pkg1')
@@ -26,6 +28,23 @@ def test_get_recursive_build_depends_in_workspace_with_test_depend():
 
     r = common.get_recursive_build_depends_in_workspace(pkg1, ordered_packages)
     assert r == ordered_packages[1:], r
+
+
+def test_get_recursive_build_depends_in_workspace_with_condition():
+    pkg = MockPackage('pkg')
+    cond_false_pkg = MockPackage('cond_false_pkg')
+    cond_false_pkg.evaluated_condition = False
+    cond_true_pkg = MockPackage('cond_true_pkg')
+    pkg.build_depends = [cond_true_pkg, cond_false_pkg]
+
+    ordered_packages = [
+        ('/path/to/pkg', pkg),
+        ('/path/to/cond_false_pkg', cond_false_pkg),
+        ('/path/to/cond_true_pkg', cond_true_pkg),
+    ]
+
+    r = common.get_recursive_build_depends_in_workspace(pkg, ordered_packages)
+    assert r == ordered_packages[2:], r
 
 
 def test_get_recursive_build_depends_in_workspace_circular_run_depend():


### PR DESCRIPTION
This adds support for the `condition` attribute in `depend` tags in the `package.xml` file by using the `evaluated_condition` attribute of `catkin_pkg`'s `Dependency` class. Closes #508.