### PR TITLE
Use loadavg over the last 1 minute

### DIFF
--- a/catkin_tools/execution/job_server.py
+++ b/catkin_tools/execution/job_server.py
@@ -219,7 +219,7 @@ class JobServer(object):
         if cls._max_load is not None:
             try:
                 load = os.getloadavg()
-                if load[1] < cls._max_load:
+                if load[0] < cls._max_load:
                     cls._load_ok = True
                 else:
                     cls._load_ok = False


### PR DESCRIPTION
Make the build process more sensitive to the current load.
We've observed that using loadavg over the last 5 minutes can be a little slow in response. 1 minute seems to be more reasonable.