### PR TITLE
Fix catkin clean --all-profiles when not at workspace root

### DIFF
--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -379,7 +379,7 @@ def main(opts):
 
     # Check for all profiles option
     if opts.all_profiles:
-        profiles = get_profile_names(opts.workspace or os.getcwd())
+        profiles = get_profile_names(opts.workspace or find_enclosing_workspace(getcwd()))
     else:
         profiles = [opts.profile]
 


### PR DESCRIPTION
Currently it silently fails because it tries to read cwd as a workspace, which may or may not contain profiles.