### PR TITLE
Check circular dependencies on catkin build

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -77,6 +77,11 @@ def determine_packages_to_be_built(packages, context, workspace_packages):
 
     # Order the packages by topology
     ordered_packages = topological_order_packages(workspace_packages)
+    # Check if there is circular dependency
+    circular_deps = [pkg for path, pkg in ordered_packages if path is None]
+    if circular_deps:
+        sys.exit("[build] There is a circular dependencies for '{0}' in the workspace"
+                 " which need to be resolved".format(circular_deps[0]))
     # Set the packages in the workspace for the context
     context.packages = ordered_packages
     # Determine the packages which should be built


### PR DESCRIPTION
`catkin_tools` reports unfriendly error when the workspace has packages that have circular dependencies like below:

```
$ catkin build
Traceback (most recent call last):
  File "/usr/bin/catkin", line 11, in <module>
    load_entry_point('catkin-tools==0.5.0', 'console_scripts', 'catkin')()
  File "/usr/lib/python3/dist-packages/catkin_tools/commands/catkin.py", line 272, in main
    catkin_main(sysargs)
  File "/usr/lib/python3/dist-packages/catkin_tools/commands/catkin.py", line 267, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/cli.py", line 404, in main
    return build_isolated_workspace(
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 318, in build_isolated_workspace
    packages_to_be_built, packages_to_be_built_deps, all_packages = determine_packages_to_be_built(
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 94, in determine_packages_to_be_built
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 94, in <listcomp>
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
AttributeError: 'str' object has no attribute 'name'
```

With this pull request, users will get package names to be resolved like below:

```
$ catkin build
[build] There is a circular dependencies for '<package name1>', '<package name2>', ... in the workspace which need to be resolved
```