### PR TITLE
Make it possible to clean individual packages with isolated layout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package catkin_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Upcoming
+--------
+
+* Add possibility to clean individual package with isolated devel space (#683)
+
 0.7.1 (2021-07-17)
 ------------------
 * Fixes in the build system requiring a version increase

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -275,7 +275,7 @@ def clean_profile(opts, profile):
                 safe_rmtree(ctx.log_space_abs, ctx.workspace, opts.force)
 
         # Find orphaned packages
-        if ctx.link_devel and not any([opts.build, opts.devel]):
+        if ctx.link_devel or ctx.isolate_devel and not any([opts.build, opts.devel]):
             if opts.orphans:
                 if os.path.exists(ctx.build_space_abs):
                     log("[clean] Determining orphaned packages...")
@@ -338,9 +338,9 @@ def clean_profile(opts, profile):
                     return False
 
         elif opts.orphans or len(opts.packages) > 0 or opts.clean_this:
-            log("[clean] Error: Individual packages can only be cleaned from "
-                "workspaces with symbolically-linked develspaces (`catkin "
-                "config --link-devel`).")
+            log("[clean] Error: Individual packages cannot be cleaned from "
+                "workspaces with merged develspaces, use a symbolically-linked "
+                "or isolated develspace instead.")
 
     except:  # noqa: E722
         # Silencing E722 here since we immediately re-raise the exception.


### PR DESCRIPTION
Currently, cleaning individual packages is only possible for a linked devel space. This pull request makes it possible for the isolated devel space, too.