### PR TITLE
Fix environment variable parsing

### DIFF
--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -203,7 +203,7 @@ def print_build_env(context, package_name):
         if pkg.name == package_name:
             environ = dict(os.environ)
             loadenv(None, None, environ, pkg, context)
-            print(format_env_dict(environ))
+            print(format_env_dict(environ, human_readable=sys.stdout.isatty()))
             return 0
     print('[build] Error: Package `{}` not in workspace.'.format(package_name),
           file=sys.stderr)

--- a/catkin_tools/verbs/catkin_env/cli.py
+++ b/catkin_tools/verbs/catkin_env/cli.py
@@ -30,7 +30,7 @@ def prepare_arguments(parser):
         help='Start with an empty environment.')
     add('-s', '--stdin', default=False, action='store_true',
         help='Read environment variable definitions from stdin. '
-             'Variables should be given in NAME=VALUE format. ')
+             'Variables should be given in NAME=VALUE format, separated by null-bytes.')
 
     add('envs_', metavar='NAME=VALUE', nargs='*', type=str, default=[],
         help='Explicitly set environment variables for the subcommand. '
@@ -102,7 +102,7 @@ def main(opts):
 
     # Update environment from stdin
     if opts.stdin:
-        input_env_str = sys.stdin.read()
+        input_env_str = sys.stdin.read().strip()
         environ.update(parse_env_str(input_env_str.encode()))
 
     # Finally, update with explicit vars


### PR DESCRIPTION
The previous approach to environment variable parsing had some issues, especially the `PATH` variable in zsh and dollar-sign strings (see #528).
This is now fixed by reading and printing the environment variables separated by null bytes, so that no shell-like parsing has to be done, which was the cause for both issues. When the output of `catkin build --get-env ...` is a terminal, the variables are printed separated by newlines, similar to `env`'s printout.

This pull request closes #528.
