### PR TITLE
WIP: Use only CATKIN_IGNORE to ignore packages, not COLCON_IGNORE/AMENT_IGNORE

### DIFF
--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -22,7 +22,7 @@ import sys
 from fnmatch import fnmatch
 from itertools import chain
 
-from catkin_pkg.packages import find_packages
+from catkin_pkg.packages import find_packages as _find_packages
 
 from .terminal_color import ColorMapper
 
@@ -519,6 +519,19 @@ def wide_log(msg, **kwargs):
     except IOError:
         # This happens when someone ctrl-c's during a log message
         pass
+
+
+def find_packages(*args, **kwargs):
+    """
+    Crawls the filesystem to find package manifest files. Ignores subfolders if an ignore_marker is present (e.g. CATKIN_IGNORE).
+    :param basepath: The path to search in, ``str``
+    :param exclude_paths: A list of paths which should not be searched, ``list``
+    :param exclude_subspaces: The flag is subfolders containing a .catkin file should not be
+        searched, ``bool``
+    :param ignore_markers: A set of filenames to be used as ignore markers, ``set``
+    :returns: A list of relative paths containing package manifest files ``list``
+    """
+    return _find_packages(*args, ignore_markers={'CATKIN_IGNORE'}, **kwargs)
 
 
 def find_enclosing_package(search_start_path=None, ws_path=None, warnings=None, symlinks=True):

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -26,7 +26,6 @@ import yaml
 try:
     from catkin_pkg.package import InvalidPackage
     from catkin_pkg.package import parse_package
-    from catkin_pkg.packages import find_packages
     from catkin_pkg.topological_order import topological_order_packages
 except ImportError as e:
     sys.exit(
@@ -36,6 +35,7 @@ except ImportError as e:
 
 from catkin_tools.common import FakeLock
 from catkin_tools.common import expand_glob_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import format_time_delta
 from catkin_tools.common import get_cached_recursive_build_depends_in_workspace
 from catkin_tools.common import get_recursive_run_depends_in_workspace

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -18,7 +18,6 @@ import os
 import sys
 
 try:
-    from catkin_pkg.packages import find_packages
     from catkin_pkg.topological_order import topological_order_packages
 except ImportError as e:
     sys.exit(
@@ -36,6 +35,7 @@ from catkin_tools.argument_parsing import add_cmake_and_make_and_catkin_make_arg
 from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.argument_parsing import configure_make_args
 from catkin_tools.common import find_enclosing_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import format_env_dict
 from catkin_tools.common import getcwd
 from catkin_tools.common import is_tty

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -22,7 +22,6 @@ from queue import Queue
 from catkin_tools.terminal_color import fmt
 
 try:
-    from catkin_pkg.packages import find_packages
     from catkin_pkg.topological_order import topological_order_packages
 except ImportError as e:
     sys.exit(
@@ -32,6 +31,7 @@ except ImportError as e:
     )
 
 from catkin_tools.common import expand_glob_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import get_recursive_build_dependents_in_workspace
 from catkin_tools.common import wide_log
 from catkin_tools.execution.controllers import ConsoleStatusController

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -17,11 +17,11 @@ import shutil
 import sys
 
 from catkin_pkg.package import InvalidPackage
-from catkin_pkg.packages import find_packages
 
 import catkin_tools.execution.job_server as job_server
 from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.common import find_enclosing_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import getcwd
 from catkin_tools.common import log
 from catkin_tools.common import wide_log

--- a/catkin_tools/verbs/catkin_list/cli.py
+++ b/catkin_tools/verbs/catkin_list/cli.py
@@ -20,6 +20,7 @@ from catkin_pkg.topological_order import topological_order_packages
 
 from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.common import find_enclosing_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import get_recursive_build_dependents_in_workspace
 from catkin_tools.common import get_recursive_build_depends_in_workspace
 from catkin_tools.common import get_recursive_run_dependents_in_workspace

--- a/catkin_tools/verbs/catkin_locate/cli.py
+++ b/catkin_tools/verbs/catkin_locate/cli.py
@@ -16,10 +16,10 @@ import os
 import sys
 
 from catkin_pkg.package import InvalidPackage
-from catkin_pkg.packages import find_packages
 
 from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.common import find_enclosing_package
+from catkin_tools.common import find_packages
 from catkin_tools.common import getcwd
 from catkin_tools.context import Context
 from catkin_tools.metadata import find_enclosing_workspace


### PR DESCRIPTION
My use case: I have a shared source space in which both ROS1 and ROS2 packages reside (the migration to ROS2 is ongoing). Now I want to build the ROS1 packages using catkin_tools, same as before, and the ROS2 packages using colcon. To do this, I place CATKIN_IGNORE files in the ROS2 packages, and COLCON_IGNORE files in the ROS1 packages.

Problem: catkin_tools/catkin_pkg ignores the ROS1 packages due to an existing COLCON_IGNORE.

I think catkin_tools should ignore ROS1 packages only when there is a CATKIN_IGNORE file present, and not when COLCON_IGNORE/AMENT_IGNORE is present.

This PR depends on a PR in catkin_pkg: https://github.com/ros-infrastructure/catkin_pkg/pull/307