### PR TITLE
Fix for issue 620

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Changelog for package catkin_tools
 Upcoming
 --------
 
+0.7.2 (2021-11-18)
+------------------
+
+* Update installation docs for python 3 (#687)
+* Fix environment variable parsing (#686)
+* Switch from Travis CI to GitHub actions (#684)
+* Regenerate setup files when the install space was cleaned (#682)
 * Add possibility to clean individual package with isolated devel space (#683)
 * Fix regeneration of setup file when the install space was cleaned (#682)
 * Fix workspace generation with catkin build --this and --start-with-this (#685)

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class PermissiveInstall(install):
 
 setup(
     name='catkin_tools',
-    version='0.7.1',
+    version='0.7.2',
     python_requires='>=3.5',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={


### PR DESCRIPTION
Edited Migration documentation to show catkin_make arguments that enable creation of custom buld, devel, install folders

[Fix for issue 620](https://github.com/catkin/catkin_tools/issues/620)