### PR TITLE
For for issue 620; rebased to master

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -52,7 +52,7 @@ To make iterating easier, use ``catkin_make`` with build and devel spaces with t
 .. code-block:: bash
 
     cd /path/to/ws
-    catkin_make --cmake-args [CMAKE_ARGS...] --make-args [MAKE_ARGS...]
+    catkin_make --build build_cm --cmake-args -DCATKIN_DEVEL_PREFIX=devel_cm -DCMAKE_INSTALL_PREFIX=install_cm [CMAKE_ARGS...] --make-args [MAKE_ARGS...]
 
 If your packages build and other appropriate tests pass, continue to the next step.
 


### PR DESCRIPTION
Edited Migration documentation to show catkin_make arguments that enable creation of custom build, devel, install folders

[Fix for issue 620](https://github.com/catkin/catkin_tools/issues/620)

(this PR is master-rebased version of [another closed PR](https://github.com/catkin/catkin_tools/pull/696))