### PR TITLE
Enable bash completion for the catkin cd verb

### DIFF
--- a/completion/catkin.bash
+++ b/completion/catkin.bash
@@ -55,7 +55,7 @@ _catkin()
   _init_completion || return # this handles default completion (variables, redirection)
 
   # complete to the following verbs
-  local catkin_verbs="build clean config create init list profile test"
+  local catkin_verbs="build cd clean config create init list profile test"
 
   # filter for long options (from bash_completion)
   local OPTS_FILTER='s/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p'
@@ -82,6 +82,9 @@ _catkin()
       else
         COMPREPLY=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       fi
+      ;;
+    cd)
+      COMPREPLY=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       ;;
     config)
       # list all options


### PR DESCRIPTION
This patch enables tab completion for the `catkin cd` shell verb (defined in [catkin_tools/verbs/catkin_shell_verbs.bash](https://github.com/Intermodalics/catkin_tools/blob/d1f55299950dbb543440b35a0e11f85b8916c1d2/catkin_tools/verbs/catkin_shell_verbs.bash)) for the bash, which I found very convenient and corresponds to the behavior of `roscd`.

Probably it can and should also be applied to [completion/_catkin](https://github.com/Intermodalics/catkin_tools/blob/d1f55299950dbb543440b35a0e11f85b8916c1d2/completion/_catkin) in a similar way, which is for [Zsh](https://www.zsh.org/) I assume, but I am not familiar with that and currently lack the time to look into or test it.