### PR TITLE
Documentation: Link to verbs/catkin_test.rst in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,7 @@ Each of the following verbs is built-in to the ``catkin`` command and has its ow
 - :doc:`list -- Find and list information about catkin packages in a workspace <verbs/catkin_list>`
 - :doc:`locate -- Get important workspace directory paths <verbs/catkin_locate>`
 - :doc:`profile -- Manage different named configuration profiles <verbs/catkin_profile>`
+- :doc:`test -- Test one or more packages in a catkin workspace <verbs/catkin_test>`
 
 Contributed Third Party Verbs
 -----------------------------


### PR DESCRIPTION
For some reason the new `test` verb (#676, documented at [verbs/catkin_test.rst](https://github.com/catkin/catkin_tools/blob/fd856e450f72441d32c015498e7f8d236596ded8/docs/verbs/catkin_test.rst) is not showing up in the documentation hosted at https://catkin-tools.readthedocs.io/en/latest/index.html:

![image](https://user-images.githubusercontent.com/2506837/145383691-5a8e92ec-7ec8-4f49-b2da-55b613d6d9c2.png)

The page https://catkin-tools.readthedocs.io/en/stable/verbs/catkin_test.html does not exist.

Not sure whether this patch alone would fix it? The [table of contents](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents) references all verbs using globbing:
```rst
.. toctree::
   :name: tocverbs
   :caption: Verb Details
   :glob:
   :hidden:
   :maxdepth: 2
   verbs/*
```