### PR TITLE
Detect nested workspaces and use the outermost workspace by default

### DIFF
--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -46,7 +46,7 @@ def add_workspace_arg(parser):
 
     add = parser.add_argument
     add('--workspace', '-w', default=None,
-        help='The path to the catkin_tools workspace or a directory contained within it (default: ".")')
+        help='The path to the catkin_tools workspace (default: autodetect)')
 
 
 def add_cmake_and_make_and_catkin_make_args(parser):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -25,7 +25,7 @@ from .common import printed_fill
 from .common import remove_ansi_escape
 from .common import terminal_width
 
-from .metadata import find_enclosing_workspace
+from .metadata import find_enclosing_workspaces
 
 from .resultspace import get_resultspace_environment
 
@@ -183,9 +183,16 @@ class Context(object):
         # Initialize dictionary version of opts namespace
         opts_vars = vars(opts) if opts else {}
 
-        # Get the workspace (either the given directory or the enclosing ws)
-        workspace_hint = workspace_hint or opts_vars.get('workspace', None) or getcwd()
-        workspace = find_enclosing_workspace(workspace_hint)
+        # Get the workspace (either the given directory or the outermost ws enclosing cwd)
+        workspace = workspace_hint or opts_vars.get('workspace', None)
+        if not workspace:
+            workspace_hint = getcwd()
+            workspaces = find_enclosing_workspaces(workspace_hint)
+            if workspaces:
+                workspace = workspaces[-1]
+            else:
+                workspace = workspace_hint
+
         if not workspace:
             if strict or not workspace_hint:
                 return None
@@ -684,7 +691,7 @@ class Context(object):
 
     def initialized(self):
         """Check if this context is initialized."""
-        return self.workspace == find_enclosing_workspace(self.workspace)
+        return self.workspace in (find_enclosing_workspaces(self.workspace) or [])
 
     @property
     def destdir(self):

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -101,6 +101,29 @@ def get_paths(workspace_path, profile_name, verb=None):
 
     return metadata_path, metadata_file_path
 
+def find_enclosing_workspaces(search_start_path):
+    """Find a catkin workspaces based on the existence of a catkin_tools
+    metadata directory starting in the path given by search_path and traversing
+    each parent directory and returns a list of workspaces.
+
+    :search_start_path: Directory which either is a catkin workspace or is
+    contained in a catkin workspace
+
+    :returns: List of path to the workspaces if found, an empty list otherwise.
+    """
+    workspaces = []
+    while search_start_path:
+        # Check if marker file exists
+        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
+        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
+            workspaces.append(search_start_path)
+
+        # Update search path or end
+        (search_start_path, child_path) = os.path.split(search_start_path)
+        if len(child_path) == 0:
+            break
+
+    return workspaces
 
 def find_enclosing_workspace(search_start_path):
     """Find a catkin workspace based on the existence of a catkin_tools
@@ -108,24 +131,18 @@ def find_enclosing_workspace(search_start_path):
     each parent directory until either finding such a directory or getting to
     the root of the filesystem.
 
+    If more than one candidate exists, returns the topmost workspace (closest
+    to the root of the filesystem.
+
     :search_start_path: Directory which either is a catkin workspace or is
     contained in a catkin workspace
 
     :returns: Path to the workspace if found, `None` if not found.
     """
-    while search_start_path:
-        # Check if marker file exists
-        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
-        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
-            return search_start_path
-
-        # Update search path or end
-        (search_start_path, child_path) = os.path.split(search_start_path)
-        if len(child_path) == 0:
-            break
-
-    return None
-
+    workspaces = find_enclosing_workspaces(search_start_path)
+    if not workspaces:
+        return None
+    return workspaces[-1]
 
 def migrate_metadata(workspace_path):
     """Migrate metadata if it's out of date."""
@@ -211,15 +228,6 @@ def init_metadata_root(workspace_path, reset=False):
         raise IOError(
             "Can't initialize Catkin workspace in path %s because it does "
             "not exist." % workspace_path)
-
-    # Check if the desired workspace is enclosed in another workspace
-    marked_workspace = find_enclosing_workspace(workspace_path)
-
-    if marked_workspace and marked_workspace != workspace_path:
-        raise IOError(
-            "Can't initialize Catkin workspace in path %s because it is "
-            "already contained in another workspace: %s." %
-            (workspace_path, marked_workspace))
 
     # Construct the full path to the metadata directory
     metadata_root_path = get_metadata_root_path(workspace_path)

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -162,7 +162,7 @@ def main(opts):
 
     except IOError as exc:
         # Usually happens if workspace is already underneath another catkin_tools workspace
-        print('error: could not configure catkin workspace: %s' % exc.message)
+        print('error: could not configure catkin workspace: %s' % str(exc))
         return 1
 
     return 0

--- a/catkin_tools/verbs/catkin_init/cli.py
+++ b/catkin_tools/verbs/catkin_init/cli.py
@@ -53,7 +53,7 @@ def main(opts):
 
     except IOError as exc:
         # Usually happens if workspace is already underneath another catkin_tools workspace
-        print('error: could not initialize catkin workspace: %s' % exc.message)
+        print('error: could not initialize catkin workspace: %s' % str(exc))
         return 1
 
     return 0

--- a/docs/verbs/cli/catkin_build.txt
+++ b/docs/verbs/cli/catkin_build.txt
@@ -24,8 +24,8 @@ the `catkin config` command.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
   --dry-run, -n         List the packages which will be built with the given

--- a/docs/verbs/cli/catkin_clean.txt
+++ b/docs/verbs/cli/catkin_clean.txt
@@ -9,8 +9,8 @@ Deletes various products of the build verb.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
   --dry-run, -n         Show the effects of the clean action without modifying

--- a/docs/verbs/cli/catkin_config.txt
+++ b/docs/verbs/cli/catkin_config.txt
@@ -30,8 +30,8 @@ profile.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 

--- a/docs/verbs/cli/catkin_init.txt
+++ b/docs/verbs/cli/catkin_init.txt
@@ -5,7 +5,7 @@ Initializes a given folder as a catkin workspace.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --reset               Reset (delete) all of the metadata for the given
                         workspace.

--- a/docs/verbs/cli/catkin_list.txt
+++ b/docs/verbs/cli/catkin_list.txt
@@ -8,8 +8,8 @@ Lists catkin packages in the workspace or other arbitrary folders.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 

--- a/docs/verbs/cli/catkin_locate.txt
+++ b/docs/verbs/cli/catkin_locate.txt
@@ -8,8 +8,8 @@ Get the paths to various locations in a workspace.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 


### PR DESCRIPTION
At the moment catkin_tools refuses to create nested workspaces with the `catkin init` verb and always uses the innermost workspace where the `.catkin_tools` marker directory is found, starting from the current working directory or the hint passed via the `--workspace` or `-w` argument.

This pull request is more meant as a question rather than a request to merge. Would a patch like that, or parts of it, be accepted for upstream, eventually with some polishing? Or does anyone has better ideas/best practices on how to solve the following use case?

**Use case:**

We sometimes commit the `.catkin_tools/profiles/*/config.yaml` files with predefined profiles to a Git repository, which is very convenient to share build profiles and commonly used cmake flags within the team. All the other files in `.catkin_tools/` are ignored by `.gitignore` entries. Some of those repositories can be included in others as Git submodules, that then symlink to all or a subset of the catkin packages from their respective source-space and typically have their own committed `.catkin_tools` directory.

Without this patch it happens that the `catkin build` and other verbs pick up the innermost workspace depending on the curent working directory, which then leads to unexpected results when sourcing the devel- or install-space of the outermost workspace and the update has not been applied.

I am aware that nesting workspaces like that may not be the smartest idea, and the more standard approach is to strictly separate source repositories and those "workspace" repositories that combine multiple source repositories, documentation, scripts, Dockerfiles etc. for a specific project. On the other hand you then always need an extra repository, for example to run CI for each source repository without replicating the build configuration.

**Proposed solution:**

Instead of the innermost, always find the outermost workspace in `find_enclosing_workspace()` and do not refuse to create nested inner workspaces if asked explicitly with `--workspace`/`-w`. The breaking change is that `--workspace`/`-w` must always point to exactly the workspace root, not to any directory within, because otherwise a call like
```sh
catkin init -w /path/to/workspace/external/nested
```
would be ambiguous again if `/path/to/workspace` already has a `.catkin_tools` marker directory. Eventually it would make sense to print a warning in case a workspace is initialized within another workspace, that then would not be used by default by `catkin`.