### PR TITLE
Correct usage check of build/skiplist

### DIFF
--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -168,10 +168,10 @@ def main(opts):
         no_action = not any(actions)
 
         # Handle old argument names necessary for Context.load
-        if opts.buildlist:
+        if opts.buildlist is not None:
             opts.whitelist = opts.buildlist
             del opts.buildlist
-        if opts.skiplist:
+        if opts.skiplist is not None:
             opts.blacklist = opts.skiplist
             del opts.skiplist
 

--- a/tests/system/verbs/catkin_config/test_config.py
+++ b/tests/system/verbs/catkin_config/test_config.py
@@ -51,3 +51,17 @@ def test_config_no_args_flags():
         assert_in_config('.', 'default', 'jobs_args', [])
         assert_in_config('.', 'default', 'make_args', [])
         assert_in_config('.', 'default', 'cmake_args', [])
+
+@in_temporary_directory
+def test_config_no_buildlist():
+    assert_cmd_success(['catkin', 'config', '--buildlist', 'mypackage'])
+    assert_in_config('.', 'default', 'whitelist', ['mypackage'])
+    assert_cmd_success(['catkin', 'config', '--no-buildlist'])
+    assert_in_config('.', 'default', 'whitelist', [])
+
+@in_temporary_directory
+def test_config_no_skiplist():
+    assert_cmd_success(['catkin', 'config', '--skiplist', 'mypackage'])
+    assert_in_config('.', 'default', 'blacklist', ['mypackage'])
+    assert_cmd_success(['catkin', 'config', '--no-skiplist'])
+    assert_in_config('.', 'default', 'blacklist', [])


### PR DESCRIPTION
In case an user uses `--no-buildlist` or `--no-skiplist` the arguments are set to an empty list, this resolves to `False` in the old situation. While it should check for it not being set at all, which is equal to `None`.

P.S. these `assert_in_config` checks need to be updated to buildlist/skiplist for the breaking release.