### PR TITLE
Migrate to noetic

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,8 +17,11 @@ jobs:
             python: 3.8
             catkin: indigo-devel
           - dist: ubuntu-20.04
+            python: 3.8
+            catkin: noetic-devel
+          - dist: ubuntu-20.04
             python: 3.9
-            catkin: indigo-devel
+            catkin: noetic-devel
 
     runs-on: ${{ matrix.versions.dist }}
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         versions:
           - dist: ubuntu-18.04

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -399,7 +399,7 @@ _catkin_create_complete() {
           pkg_opts=(\
             {-h,--help}'[Show usage help]'\
             {-p,--path}'[The path into which the package should be generated]:path:_files'\
-            '--rosdistro[Which ROS distro to use for the template]:rosdistro:(hydro indigo jade kinetic)'\
+            '--rosdistro[Which ROS distro to use for the template]:rosdistro:(melodic noetic)'\
             {-v,--version}'[Version MAJOR.MINOR.PATCH]:version'\
             {-l,--license}'[Software license for distribution]:license:(BSD MIT GPLV3)'\
             {-d,--description}'[Package description]:description'\

--- a/completion/_catkin
+++ b/completion/_catkin
@@ -156,14 +156,14 @@ _catkin_get_packages() {
     zstyle ":completion:${curcontext}:" cache-policy _catkin_packages_caching_policy
   fi
 
-  # If cache is invalid, or if the package list or workspace cache file path are not set yet or this path differ from 
+  # If cache is invalid, or if the package list or workspace cache file path are not set yet or this path differ from
   # its located path (we switched to different workspace) and variables can't be retrieved from cache regenerate cache
   # ( Remember that _retrieve_cache returns 0 if everything's fine, 1 if not. _cache_invalid returns 0 if cache needs rebuilding, 1 otherwise)
   # (see https://unix.stackexchange.com/q/588662 for the use of parentheses)
   if _cache_invalid workspace_packages || \
-    {{ [[ ${+_workspace_packages} -eq 0 ]] || 
-      [[ -z "$_workspace_cache_file_path" ]] ||  
-      [[ "$_workspace_cache_file_path" != "$cache_file_path" ]] } && 
+    {{ [[ ${+_workspace_packages} -eq 0 ]] ||
+      [[ -z "$_workspace_cache_file_path" ]] ||
+      [[ "$_workspace_cache_file_path" != "$cache_file_path" ]] } &&
       ! _retrieve_cache workspace_packages } ; then
 
     _debug_log "Regenerating package cache because retrieval failed ..."

--- a/docs/advanced/verb_customization.rst
+++ b/docs/advanced/verb_customization.rst
@@ -8,7 +8,7 @@ The Built-In Aliases
 ^^^^^^^^^^^^^^^^^^^^
 
 You can list the available aliases using the ``--list-aliases`` option to the ``catkin`` command.
-Below are the built-in aliases as displayed by this command: 
+Below are the built-in aliases as displayed by this command:
 
 .. code-block:: bash
 
@@ -25,19 +25,19 @@ Defining Additional Aliases
 Verb aliases are defined in the ``verb_aliases`` sub-directory of the catkin config folder, ``~/.config/catkin/verb_aliases``.
 Any YAML files in that folder (files with a ``.yaml`` extension) will be processed as definition files.
 
-These files are formatted as simple YAML dictionaries which map aliases to expanded expressions, which must be composed of other ``catkin`` verbs, options, or aliases: 
+These files are formatted as simple YAML dictionaries which map aliases to expanded expressions, which must be composed of other ``catkin`` verbs, options, or aliases:
 
 .. code-block:: yaml
 
   <ALIAS>: <EXPRESSION>
 
-For example, aliases which configure a workspace profile so that it ignores the value of the ``CMAKE_PREFIX_PATH`` environment variable, and instead *extends* one or another ROS install spaces could be defined as follows: 
+For example, aliases which configure a workspace profile so that it ignores the value of the ``CMAKE_PREFIX_PATH`` environment variable, and instead *extends* one or another ROS install spaces could be defined as follows:
 
 .. code-block:: yaml
 
   # ~/.config/catkin/verb_aliases/10-ros-distro-aliases.yaml
-  extend-sys: config --profile sys --extend /opt/ros/indigo -x _sys
-  extend-overlay: config --profile overlay --extend ~/ros/indigo/install -x _overlay
+  extend-sys: config --profile sys --extend /opt/ros/noetic -x _sys
+  extend-overlay: config --profile overlay --extend ~/ros/noetic/install -x _overlay
 
 After defining these aliases, one could use them with optional additional options and build a given configuration profile.
 
@@ -67,7 +67,7 @@ For example, the ``bt: build --this`` alias exists in the default alias file, ``
     bt: build --this --no-deps
 
 You can also disable or unset an alias by setting its value to ``null``.
-For example, the ``ls: list`` alias is defined in the default aliases, but you can override it with this entry in a custom file named something like ``02-unset.yaml``: 
+For example, the ``ls: list`` alias is defined in the default aliases, but you can override it with this entry in a custom file named something like ``02-unset.yaml``:
 
 .. code-block:: yaml
 
@@ -79,7 +79,7 @@ Recursive Alias Expansion
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Additionally, verb aliases can be recursive, for instance in the ``bt`` alias, the ``b`` alias expands to ``build`` so that ``b --this`` expands to ``build --this``.
-The ``catkin`` command shows the expansion of aliases when they are invoked so that their behavior is more transparent: 
+The ``catkin`` command shows the expansion of aliases when they are invoked so that their behavior is more transparent:
 
 .. code-block:: bash
 

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -18,7 +18,7 @@ Initialize a workspace with a default layout (``src``/``build``/``devel``) in th
   - ``catkin init --workspace /tmp/path/to/my_catkin_ws``
 
 ... which explicitly extends another workspace:
-  - ``catkin config --init --extend /opt/ros/indigo``
+  - ``catkin config --init --extend /opt/ros/noetic``
 
 Initialize a workspace with a **source space** called ``other_src``:
   - ``catkin config --init --source-space other_src``
@@ -139,7 +139,7 @@ Change from implicit to explicit chaining:
   .. code-block:: bash
 
     catkin clean
-    catkin config --extend /opt/ros/indigo
+    catkin config --extend /opt/ros/noetic
 
 Change from explicit to implicit chaining:
   .. code-block:: bash
@@ -154,13 +154,13 @@ Build with ``distcc``:
   .. code-block:: bash
 
      CC="distcc gcc" CXX="distcc g++" catkin build -p$(distcc -j) -j$(distcc -j) --no-jobserver
-     
+
 Changing Package's Build Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Set the build type to ``cmake`` in the ``package.xml`` file's ``<export/>`` section:
   .. code-block:: xml
-    
+
     <export>
       <build_type>cmake</build_type>
     </export>

--- a/docs/examples/failure_ws/all.bash
+++ b/docs/examples/failure_ws/all.bash
@@ -7,7 +7,7 @@ pushd `dirname $0`
 
 rm -rf $WS
 
-source /opt/ros/indigo/setup.bash
+source /opt/ros/noetic/setup.bash
 bash 0_init.bash
 $SLOWRECORD --check --tall --buffer 1_build_warning.bash
 $SLOWRECORD --check --tall --buffer 2_build_err.bash

--- a/docs/examples/quickstart_ws/0_quickstart.bash
+++ b/docs/examples/quickstart_ws/0_quickstart.bash
@@ -1,4 +1,4 @@
-source /opt/ros/indigo/setup.bash          # Source ROS indigo to use Catkin
+source /opt/ros/noetic/setup.bash          # Source ROS noetic to use Catkin
 mkdir -p /tmp/quickstart_ws/src            # Make a new workspace and source space
 cd /tmp/quickstart_ws                      # Navigate to the workspace root
 catkin init                                # Initialize it with a hidden marker file

--- a/docs/examples/ros_tutorials_ws/0_checkout.bash
+++ b/docs/examples/ros_tutorials_ws/0_checkout.bash
@@ -1,4 +1,4 @@
-export ROS_DISTRO=indigo                                 # Set ROS distribution
+export ROS_DISTRO=noetic                                 # Set ROS distribution
 mkdir -p /tmp/ros_tutorials_ws/src                       # Create workspace
 cd /tmp/ros_tutorials_ws/src                             # Navigate to source space
 rosinstall_generator --deps ros_tutorials > .rosinstall  # Get list of pakcages

--- a/docs/examples/ros_tutorials_ws/all.bash
+++ b/docs/examples/ros_tutorials_ws/all.bash
@@ -7,7 +7,7 @@ pushd `dirname $0`
 
 rm -rf $WS
 
-source /opt/ros/indigo/setup.bash
+source /opt/ros/noetic/setup.bash
 
 $SLOWRECORD --check --tall 0_checkout.bash
 $SLOWRECORD --check --tall --buffer 1_init.bash

--- a/docs/mechanics.rst
+++ b/docs/mechanics.rst
@@ -324,11 +324,11 @@ Implicit Chaining via ``CMAKE_PREFIX_PATH`` Environment or Cache Variable
 In this case, the ``catkin`` command is *implicitly* assuming that you want to build this workspace against resources which have been built into the directories listed in your ``CMAKE_PREFIX_PATH`` environment variable.
 As such, you can control this value simply by changing this environment variable.
 
-For example, ROS users who load their system's installed ROS environment by calling something similar to ``source /opt/ros/indigo/setup.bash`` will normally see an ``Extending`` value such as:
+For example, ROS users who load their system's installed ROS environment by calling something similar to ``source /opt/ros/noetic/setup.bash`` will normally see an ``Extending`` value such as:
 
 .. code-block:: bash
 
-      Extending:             [env] /opt/ros/indigo
+      Extending:             [env] /opt/ros/noetic
 
 If you don't want to extend the given workspace, unsetting the ``CMAKE_PREFIX_PATH`` environment variable will change it back to none.
 Once you have built your workspace once, this ``CMAKE_PREFIX_PATH`` will be cached by the underlying CMake buildsystem.
@@ -336,7 +336,7 @@ As such, the ``Extending`` status will subsequently describe this as the "cached
 
 .. code-block:: bash
 
-      Extending:          [cached] /opt/ros/indigo
+      Extending:          [cached] /opt/ros/noetic
 
 Once the extension mode is cached like this, you must use ``catkin clean`` to before changing it to something else.
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -39,7 +39,7 @@ Incorrect Resolution of Workspace Overlays
 It's possible for a CMake package to include header directories as ``SYSTEM`` includes pointing to the workspace root include directory (like ``/path/to/ws/devel/include``).
 If this happens, CMake will ignore any "normal" includes to that path, and prefer the ``SYSTEM`` include.
 This means that ``/path/to/ws/devel/include`` will be searched *after* any other normal includes.
-If another package specifies ``/opt/ros/indigo/include`` as a normal include, it will take precedence.
+If another package specifies ``/opt/ros/noetic/include`` as a normal include, it will take precedence.
 
 - Minimal example here: https://github.com/jbohren/isystem
 - Overview of GCC's system include precedence here: https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html
@@ -48,7 +48,7 @@ As a workaround, you can force CMake to ignore all specified root include direct
 
 .. code-block:: bash
 
-    catkin config -a --cmake-args -DCMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES="/opt/ros/indigo/include"
+    catkin config -a --cmake-args -DCMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES="/opt/ros/noetic/include"
 
 This is actually a bug in CMake and has been reported here: https://cmake.org/Bug/view.php?id=15970
 

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -56,7 +56,7 @@ This is also sometimes referred to as "workspace chaining" and sometimes the ext
 
 With ``catkin config``, you can explicitly set the workspace you want to extend, using the ``--extend`` argument.
 This is equivalent to sourcing a setup file, building, and then reverting to the environment before sourcing the setup file.
-For example, regardless of your current environment variable settings (like ``$CMAKE_PREFIX_PATH``), using ``--extend`` can build your workspace against the ``/opt/ros/indigo`` install space.
+For example, regardless of your current environment variable settings (like ``$CMAKE_PREFIX_PATH``), using ``--extend`` can build your workspace against the ``/opt/ros/noetic`` install space.
 
 Note that in case the desired parent workspace is different from one already being used, using the ``--extend`` argument also necessitates cleaning your workspace with ``catkin clean``.
 
@@ -100,16 +100,16 @@ At this point you have a workspace which doesn't extend anything.
 With the default **devel space** layout, this won't build without the ``catkin`` CMake package, since this package is used to generate setup files.
 
 If you realize this after the fact, you still can explicitly tell ``catkin build`` to extend  some result space.
-Suppose you wanted to extend a standard ROS system install like ``/opt/ros/indigo``.
+Suppose you wanted to extend a standard ROS system install like ``/opt/ros/noetic``.
 This can be done with the ``--extend`` option like so:
 
 .. code-block:: bash
 
     $ catkin clean
-    $ catkin config --extend /opt/ros/indigo
+    $ catkin config --extend /opt/ros/noetic
     --------------------------------------------------------------
     Profile:                     default
-    Extending:        [explicit] /opt/ros/indigo
+    Extending:        [explicit] /opt/ros/noetic
     Workspace:                   /tmp/path/to/my_catkin_ws
     --------------------------------------------------------------
     Source Space:       [exists] /tmp/path/to/my_catkin_ws/src
@@ -132,7 +132,7 @@ This can be done with the ``--extend`` option like so:
 
     $ source devel/setup.bash
     $ echo $CMAKE_PREFIX_PATH
-    /tmp/path/to/my_catkin_ws:/opt/ros/indigo
+    /tmp/path/to/my_catkin_ws:/opt/ros/noetic
 
 
 Buildlisting and Skiplisting Packages

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ pip install git+https://github.com/osrf/osrf_pycommon.git
 Second, build the Catkin CMake tool:
 
 ```
-git clone https://github.com/ros/catkin.git /tmp/catkin_source -b indigo-devel --depth 1
+git clone https://github.com/ros/catkin.git /tmp/catkin_source -b noetic-devel --depth 1
 mkdir /tmp/catkin_source/build
 pushd /tmp/catkin_source/build
 cmake .. && make

--- a/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(app_pkg)
 
+include_directories(${CMAKE_INSTALL_PREFIX}/include)
 add_executable(vanilla_app vanilla.cpp)
 find_library(LIBVANILLA vanilla)
 target_link_libraries(vanilla_app ${LIBVANILLA})
@@ -9,4 +10,3 @@ install(TARGETS vanilla_app
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib/static)
-

--- a/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(app_pkg)
 
-include_directories($ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/include)
+find_package(lib_pkg REQUIRED)
+
+include_directories(${lib_pkg_INCLUDE_DIRS})
+
 add_executable(vanilla_app vanilla.cpp)
-find_library(LIBVANILLA vanilla)
-target_link_libraries(vanilla_app ${LIBVANILLA})
+target_link_libraries(vanilla_app vanilla)
 
 install(TARGETS vanilla_app
   RUNTIME DESTINATION bin

--- a/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(app_pkg)
 
-include_directories(${CMAKE_INSTALL_PREFIX}/include)
+include_directories($ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/include)
 add_executable(vanilla_app vanilla.cpp)
 find_library(LIBVANILLA vanilla)
 target_link_libraries(vanilla_app ${LIBVANILLA})

--- a/tests/system/resources/cmake_pkgs/lib_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/lib_pkg/CMakeLists.txt
@@ -1,15 +1,48 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(lib_pkg)
 
+# make cache variables for install destinations
+include(GNUInstallDirs)
+
 include_directories(${CMAKE_SOURCE_DIR})
 add_library(vanilla SHARED vanilla.cpp)
 
-INSTALL(FILES vanilla.h
-  DESTINATION include
-  )
-
+# install the target and create export-set
 install(TARGETS vanilla
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  EXPORT vanillaTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
+# install header file
+INSTALL(FILES vanilla.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# generate and install export file
+install(EXPORT vanillaTargets
+        FILE vanillaTargets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lib_pkg
+)
+
+# include CMakePackageConfigHelpers macro
+include(CMakePackageConfigHelpers)
+
+# create config file
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/lib_pkgConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lib_pkg
+)
+
+# install config files
+install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/lib_pkgConfig.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lib_pkg
+)
+
+# generate the export targets for the build tree
+export(EXPORT vanillaTargets
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/vanillaTargets.cmake"
+)

--- a/tests/system/resources/cmake_pkgs/lib_pkg/Config.cmake.in
+++ b/tests/system/resources/cmake_pkgs/lib_pkg/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/vanillaTargets.cmake")
+
+check_required_components(vanilla)


### PR DESCRIPTION
Test against `noetic-devel` branch of catkin for Ubuntu 20.04
Migrate docs to noetic