### PR TITLE
remove leading and trailing ':' in CMAKE_PREFIX_PATH

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -449,7 +449,7 @@ class Context(object):
 
         self.cached_cmake_prefix_path = ''
         if 'CMAKE_PREFIX_PATH' in sticky_env:
-            split_result_cmake_prefix_path = sticky_env.get('CMAKE_PREFIX_PATH', '').split(':')
+            split_result_cmake_prefix_path = sticky_env.get('CMAKE_PREFIX_PATH', '').strip(':').split(':')
             if len(split_result_cmake_prefix_path) > 1:
                 self.cached_cmake_prefix_path = ':'.join(split_result_cmake_prefix_path[1:])
 
@@ -457,7 +457,7 @@ class Context(object):
         self.env_cmake_prefix_path = ''
         if self.extend_path:
             extended_env = get_resultspace_environment(self.extend_path, quiet=False)
-            self.env_cmake_prefix_path = extended_env.get('CMAKE_PREFIX_PATH', '')
+            self.env_cmake_prefix_path = extended_env.get('CMAKE_PREFIX_PATH', '').strip(':')
             if not self.env_cmake_prefix_path:
                 print(clr("@!@{rf}Error:@| Could not load environment from workspace: '{}', "
                           "target environment (env.sh) does not provide 'CMAKE_PREFIX_PATH'").format(self.extend_path))
@@ -466,14 +466,14 @@ class Context(object):
         else:
             # Get the current CMAKE_PREFIX_PATH
             if 'CMAKE_PREFIX_PATH' in os.environ:
-                split_result_cmake_prefix_path = os.environ['CMAKE_PREFIX_PATH'].split(':')
+                split_result_cmake_prefix_path = os.environ['CMAKE_PREFIX_PATH'].strip(':').split(':')
                 if len(split_result_cmake_prefix_path) > 1 and (
                         (not self.install and split_result_cmake_prefix_path[0] == self.devel_space_abs) or
                         (self.install and split_result_cmake_prefix_path[0] == self.install_space_abs)):
 
                     self.env_cmake_prefix_path = ':'.join(split_result_cmake_prefix_path[1:])
                 else:
-                    self.env_cmake_prefix_path = os.environ.get('CMAKE_PREFIX_PATH', '').rstrip(':')
+                    self.env_cmake_prefix_path = os.environ.get('CMAKE_PREFIX_PATH', '').strip(':')
 
         # Add warning for empty extend path
         if (self.devel_layout == 'linked' and


### PR DESCRIPTION
I had some CMAKE_PREFIX_PATH modifications like the following that resulted in leading `:`

```
export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/my/path/...
```

and the result is that `::` gets baked into the CMAKE_PREFIX_PATH later, but then a mismatch occurs:

```
WARNING: Your current environment's CMAKE_PREFIX_PATH is different from the cached CMAKE_PREFIX_PATH used the last
time this workspace was built.

If you want to use a different CMAKE_PREFIX_PATH you should call `catkin clean` to remove all references to the previous
CMAKE_PREFIX_PATH.

Cached CMAKE_PREFIX_PATH:
	/home/lucasw/base_catkin_ws/devel:/home/lucasw/other/install:/home/lucasw/other/install/lib/cmake
Current CMAKE_PREFIX_PATH:
	/home/lucasw/base_catkin_ws/devel::/home/lucasw/other/install:/home/lucasw/other/install/lib/cmake
```

so added `strip(':')` everywhere CMAKE_PREFIX_PATH is loaded from the environment