### PR TITLE
Use inspect.getfullargspec where available

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,7 +115,10 @@ def in_temporary_directory(f):
     @functools.wraps(f)
     def decorated(*args, **kwds):
         with temporary_directory() as directory:
-            from inspect import getargspec
+            try:
+                from inspect import getfullargspec as getargspec
+            except ImportError:
+                from inspect import getargspec
 
             # If it takes directory of kwargs and kwds does already have
             # directory, inject it

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,14 +115,10 @@ def in_temporary_directory(f):
     @functools.wraps(f)
     def decorated(*args, **kwds):
         with temporary_directory() as directory:
-            try:
-                from inspect import getfullargspec as getargspec
-            except ImportError:
-                from inspect import getargspec
-
+            from inspect import getfullargspec
             # If it takes directory of kwargs and kwds does already have
             # directory, inject it
-            if 'directory' not in kwds and 'directory' in getargspec(f)[0]:
+            if 'directory' not in kwds and 'directory' in getfullargspec(f)[0]:
                 kwds['directory'] = directory
             return f(*args, **kwds)
     decorated.__name__ = f.__name__

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -116,6 +116,7 @@ def in_temporary_directory(f):
     def decorated(*args, **kwds):
         with temporary_directory() as directory:
             from inspect import getfullargspec
+
             # If it takes directory of kwargs and kwds does already have
             # directory, inject it
             if 'directory' not in kwds and 'directory' in getfullargspec(f)[0]:


### PR DESCRIPTION
The inspect.getargspec function has been deprecated since Python 3.0, where getfullargspec was introduced to replace it. ~~We still need to support getargspec for Python 2.~~

This change is needed to support Python 3.11, where inspect.getargspec has been removed.

Fixes #730