### PR TITLE
Add warned packages to summary

### DIFF
--- a/catkin_tools/execution/controllers.py
+++ b/catkin_tools/execution/controllers.py
@@ -316,12 +316,12 @@ class ConsoleStatusController(threading.Thread):
                 abandoneds[jid] = templates['abandoned']
 
         # Combine successfuls and ignoreds, sort by key
-        if len(successfuls) + len(ignoreds) > 0:
+        if len(successfuls) + len(warneds) + len(ignoreds) > 0:
             wide_log("")
             wide_log(clr("[{}] Successful {}:").format(self.label, self.jobs_label))
             wide_log("")
             print_items_in_columns(
-                sorted(itertools.chain(successfuls.items(), ignoreds.items())),
+                sorted(itertools.chain(successfuls.items(), warneds.items(), ignoreds.items())),
                 number_of_columns)
         else:
             wide_log("")


### PR DESCRIPTION
This PR fixes https://github.com/catkin/catkin_tools/issues/738 by adding packages which have `Warned` status to the build summary.