### PR TITLE
Always add prebuild jobs as dependencies, even with --no-deps

### DIFF
--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -499,9 +499,8 @@ def build_isolated_workspace(
             if p.name not in prebuild_jobs
         ]
         # All jobs depend on the prebuild jobs if they're defined
-        if not no_deps:
-            for j in prebuild_jobs.values():
-                deps.append(j.jid)
+        for j in prebuild_jobs.values():
+            deps.append(j.jid)
 
         # Determine the job parameters
         build_job_kwargs = dict(


### PR DESCRIPTION
This pull request enforces that packages that have to be built before the others (normally either `catkin` or `catkin_tools_prebuild`) are built before the other packages even if `--no-deps` is specified. Currently they are built in parallel to the other packages which makes no sense.
Fixes #736 and fixes #737.