### PR TITLE
Fix incorrect argument forwarding with shell verbs

### DIFF
--- a/catkin_tools/verbs/catkin_shell_verbs.bash
+++ b/catkin_tools/verbs/catkin_shell_verbs.bash
@@ -54,11 +54,7 @@ function catkin() {
   fi
 
   # Capture original args
-  if [[ "$SHELL_EXT" == "bash" ]]; then
-      ORIG_ARGS=$@
-  else
-      ORIG_ARGS=(${@[*]})
-  fi
+  ORIG_ARGS=("$@")
 
   # Handle main arguments
   OPTSPEC=":hw-:"
@@ -100,6 +96,6 @@ function catkin() {
   case "${SUBCOMMAND}" in
     cd) cd "$($CATKIN locate $MAIN_ARGS $@)";;
     source) source "$($CATKIN locate $MAIN_ARGS -d)/setup.$SHELL_EXT";;
-    *) $CATKIN ${ORIG_ARGS}
+    *) $CATKIN "${ORIG_ARGS[@]}"
   esac
 }


### PR DESCRIPTION
When used with bash, the shell verbs script would split each quoted argument into multiple arguments, breaking commands such as `catkin config --cmake-args -DCMAKE_CXX_FLAGS="-Ofast -DNDEBUG"`. This PR should fix the problem.