### PR TITLE
Use explicit asyncio task creation to fix broken python3.11

### DIFF
--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -384,4 +384,3 @@ def run_until_complete(coroutine):
 
     # Run jobs
     return loop.run_until_complete(task)
-

--- a/catkin_tools/execution/executor.py
+++ b/catkin_tools/execution/executor.py
@@ -380,5 +380,8 @@ def run_until_complete(coroutine):
     loop = get_loop()
     loop.slow_callback_duration = 1.0
 
+    task = loop.create_task(coroutine)
+
     # Run jobs
-    return loop.run_until_complete(coroutine)
+    return loop.run_until_complete(task)
+


### PR DESCRIPTION
Catkin build currently doesn't work on Python3.11 due to
In Python3.11, [passing coroutine objects to wait() directly is forbidden](https://docs.python.org/3/library/asyncio-task.html#:~:text=Changed%20in%20version%203.11%3A%20Passing%20coroutine%20objects%20to%20wait()%20directly%20is%20forbidden.). 
This PR changes to the new asyncio setup to allow catkin build to run.

Not tested with earlier versions of Python.