### PR TITLE
chore: fix cmake min version deprecation warning

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -732,7 +732,7 @@ DEVEL_LINK_BLACKLIST = DEVEL_LINK_SKIPLIST
 
 # CMakeLists.txt for prebuild package
 SETUP_PREBUILD_CMAKELISTS_TEMPLATE = """\
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(catkin_tools_prebuild)
 
 find_package(catkin QUIET)

--- a/docs/examples/failure_ws/src/catkin_pkg_cmake_err/CMakeLists.txt
+++ b/docs/examples/failure_ws/src/catkin_pkg_cmake_err/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(catkin_pkg_cmake_err)
 
 ## Find catkin macros and libraries

--- a/docs/examples/failure_ws/src/catkin_pkg_cmake_warn/CMakeLists.txt
+++ b/docs/examples/failure_ws/src/catkin_pkg_cmake_warn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(catkin_pkg_cmake_warn)
 
 ## Find catkin macros and libraries

--- a/docs/examples/failure_ws/src/catkin_pkg_make_err/CMakeLists.txt
+++ b/docs/examples/failure_ws/src/catkin_pkg_make_err/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(catkin_pkg_make_err)
 
 ## Find catkin macros and libraries

--- a/docs/examples/failure_ws/src/catkin_pkg_make_warn/CMakeLists.txt
+++ b/docs/examples/failure_ws/src/catkin_pkg_make_warn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(catkin_pkg_make_warn)
 
 ## Find catkin macros and libraries

--- a/tests/system/resources/catkin_pkgs/build_type_condition/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/build_type_condition/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(build_type_condition)

--- a/tests/system/resources/catkin_pkgs/cmake_args/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/cmake_args/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_args)
 
 find_package(catkin REQUIRED)
@@ -16,4 +16,3 @@ endif()
 if(NOT VAR3)
   message(SEND_ERROR "VAR3 NOT DEFINED!")
 endif()
-

--- a/tests/system/resources/catkin_pkgs/cmake_err/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/cmake_err/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_err)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tests/system/resources/catkin_pkgs/cmake_warning/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/cmake_warning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_warning)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tests/system/resources/catkin_pkgs/depend_condition/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/depend_condition/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(build_type_condition)

--- a/tests/system/resources/catkin_pkgs/make_err/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/make_err/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(make_err)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tests/system/resources/catkin_pkgs/make_warning/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/make_warning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(make_warning)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tests/system/resources/catkin_pkgs/products_0/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/products_0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(products_0)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/catkin_pkgs/products_unicode/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/products_unicode/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(products_unicode)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/catkin_pkgs/python_pkg/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/python_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(python_pkg)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/catkin_pkgs/python_tests/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/python_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(python_tests)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/catkin_pkgs/python_tests_err/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/python_tests_err/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(python_tests_err)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/catkin_pkgs/python_tests_targets/CMakeLists.txt
+++ b/tests/system/resources/catkin_pkgs/python_tests_targets/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(python_tests_targets)
 find_package(catkin REQUIRED)
 

--- a/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/app_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(app_pkg)
 
 find_package(lib_pkg REQUIRED)

--- a/tests/system/resources/cmake_pkgs/cmake_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/cmake_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_pkg)
 
 add_executable(vanilla vanilla.cpp)
@@ -7,4 +7,3 @@ install(TARGETS vanilla
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib/static)
-

--- a/tests/system/resources/cmake_pkgs/lib_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/lib_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(lib_pkg)
 
 # make cache variables for install destinations

--- a/tests/system/resources/cmake_pkgs/test_err_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/test_err_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(test_err_pkg)
 
 include(CTest)

--- a/tests/system/resources/cmake_pkgs/test_pkg/CMakeLists.txt
+++ b/tests/system/resources/cmake_pkgs/test_pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(test_pkg)
 
 include(CTest)

--- a/tests/system/resources/ros_pkgs/pkg_with_roslint/CMakeLists.txt
+++ b/tests/system/resources/ros_pkgs/pkg_with_roslint/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(pkg_with_roslint)
 find_package(catkin REQUIRED COMPONENTS roslint)
 catkin_package()

--- a/tests/system/workspace_factory.py
+++ b/tests/system/workspace_factory.py
@@ -52,13 +52,13 @@ class WorkspaceFactory(object):
   </export>"""
 
         CATKIN_CMAKELISTS_TEMPLATE = """
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project({name})
 find_package(catkin REQUIRED COMPONENTS {catkin_components})
 catkin_package()"""
 
         CMAKE_CMAKELISTS_TEMPLATE = """
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project({name})
 {find_packages}
 add_custom_target(install)"""

--- a/tests/system/workspace_factory.py
+++ b/tests/system/workspace_factory.py
@@ -61,7 +61,8 @@ catkin_package()"""
 cmake_minimum_required(VERSION 3.10)
 project({name})
 {find_packages}
-add_custom_target(install)"""
+install(FILES ${{CMAKE_CURRENT_SOURCE_DIR}}/package.xml DESTINATION share/${{PROJECT_NAME}})
+"""
 
         CMAKE_CMAKELISTS_FIND_PACKAGE_TEMPLATE = """
 find_package({name})"""


### PR DESCRIPTION
Not sure if this is desirable given back-compatibility, but this pull request fixed the cmake min version < 3.5 deprecation warning:

```bash
Warnings   << catkin_pkg_make_err:cmake /home/ricks/development/work/catkin_tools_ws/logs/catkin_pkg_make_err/build.cmake.000.log                                                                          
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):                                                                                                                                    
  Compatibility with CMake < 3.5 will be removed from a future version of                                                                                                                                  
  CMake.                                                                                                                                                                                                   
                                                                                                                                                                                                           
  Update the VERSION argument <min> value or use a ...<max> suffix to tell                                                                                                                                 
  CMake that the project does not need compatibility with older versions.
```