### PR TITLE
add `catkin build --no-make` option to build `cmake only` and not to run `make`

### DIFF
--- a/catkin_tools/jobs/catkin.py
+++ b/catkin_tools/jobs/catkin.py
@@ -363,7 +363,7 @@ def link_devel_products(
     return 0
 
 
-def create_catkin_build_job(context, package, package_path, dependencies, force_cmake, pre_clean, prebuild=False):
+def create_catkin_build_job(context, package, package_path, dependencies, force_cmake, pre_clean, no_make, prebuild=False):
     """Job class for building catkin packages"""
 
     # Package source space path
@@ -447,6 +447,13 @@ def create_catkin_build_job(context, package, package_path, dependencies, force_
             logger_factory=CMakeIOBufferProtocol.factory_factory(pkg_dir),
             occupy_job=True
         ))
+
+    if no_make:
+        return Job(
+            jid=package.name,
+            deps=dependencies,
+            env=job_env,
+            stages=stages)
 
     # Filter make arguments
     make_args = handle_make_arguments(

--- a/catkin_tools/jobs/cmake.py
+++ b/catkin_tools/jobs/cmake.py
@@ -205,7 +205,7 @@ def generate_setup_file(logger, event_queue, context, install_target):
     return 0
 
 
-def create_cmake_build_job(context, package, package_path, dependencies, force_cmake, pre_clean):
+def create_cmake_build_job(context, package, package_path, dependencies, force_cmake, pre_clean, no_make):
 
     # Package source space path
     pkg_dir = os.path.join(context.source_space_abs, package_path)
@@ -279,6 +279,13 @@ def create_cmake_build_job(context, package, package_path, dependencies, force_c
             cwd=build_space,
             logger_factory=CMakeIOBufferProtocol.factory_factory(pkg_dir)
         ))
+
+    if no_make:
+        return Job(
+            jid=package.name,
+            deps=dependencies,
+            env=job_env,
+            stages=stages)
 
     # Pre-clean command
     if pre_clean:

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -193,6 +193,7 @@ def build_isolated_workspace(
     no_notify=False,
     continue_on_failure=False,
     summarize_build=None,
+    no_make=False,
 ):
     """Builds a catkin workspace in isolation
 
@@ -237,6 +238,8 @@ def build_isolated_workspace(
     :param summarize_build: if True summarizes the build at the end, if None and continue_on_failure is True and the
         the build fails, then the build will be summarized, but if False it never will be summarized.
     :type summarize_build: bool
+    :param no_make: builds cmake file only and does not build packages
+    :type no_make: bool
 
     :raises: SystemExit if buildspace is a file or no packages were found in the source space
         or if the provided options are invalid
@@ -464,6 +467,7 @@ def build_isolated_workspace(
                 dependencies=prebuild_pkg_deps,
                 force_cmake=force_cmake,
                 pre_clean=pre_clean,
+                no_make=False,
                 prebuild=True)
 
             # Add the prebuld job
@@ -509,7 +513,9 @@ def build_isolated_workspace(
             package_path=pkg_path,
             dependencies=deps,
             force_cmake=force_cmake,
-            pre_clean=pre_clean)
+            pre_clean=pre_clean,
+            no_make=no_make,
+        )
 
         # Create the job based on the build type
         build_type = pkg.get_build_type()

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -110,6 +110,8 @@ the --save-config argument. To see the current config, use the
         help='Runs `make clean` before building each package.')
     add('--no-install-lock', action='store_true', default=None,
         help='Prevents serialization of the install steps, which is on by default to prevent file install collisions')
+    add('--no-make', action='store_true', default=False,
+        help='Generates cmake files only and does not build packages.')
 
     config_group = parser.add_argument_group('Config', 'Parameters for the underlying build system.')
     add = config_group.add_argument
@@ -393,7 +395,8 @@ def main(opts):
             lock_install=not opts.no_install_lock,
             no_notify=opts.no_notify,
             continue_on_failure=opts.continue_on_failure,
-            summarize_build=opts.summarize  # Can be True, False, or None
+            summarize_build=opts.summarize,  # Can be True, False, or None
+            no_make=opts.no_make,
         )
     except CommandMissing as e:
         sys.exit(clr("[build] @!@{rf}Error:@| {0}").format(e))


### PR DESCRIPTION
this PR adds `catkin build --no-make` options for `catkin build`.
with this option, we can only run `cmake` and skip `make` commands during `catkin build`.

this option is useful when we use `clang-tidy`, because it only requires `cmake`.
for example, we can run `catkin build --no-make` and run `clang-tidy` like this.

## sample

```
mkdir catkin_ws/src -p
cd catkin_ws/src
git clone https://github.com/ros/geometry_tutorials
cd ..
catkin config --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
catkin build --no-make
clang-tidy -p build/turtle_tf2 src/geometry_tutorials/turtle_tf2/src/message_filter.cpp
```