### PR TITLE
Use unittest.mock instead of standalone mock package

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ First, make sure the required test dependencies are installed:
 
 ```
 pip install argparse catkin-pkg distribute PyYAML psutil
-pip install nose coverage flake8 mock empy --upgrade
+pip install nose coverage flake8 empy --upgrade
 pip install git+https://github.com/osrf/osrf_pycommon.git
 ```
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from catkin_tools import common
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 
-import mock
+from unittest import mock
 import pytest
 
 from catkin_tools import config


### PR DESCRIPTION
The functionality provided by 'mock' was integrated into the 'unittest' package in Python 3.3. This package requires at least Python 3.5, so we can switch to the unittest-provided package unconditionally.