### PR TITLE
Replace pkg_resources by importlib.metadata

### DIFF
--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -19,9 +19,9 @@ from datetime import date
 from shlex import quote as cmd_quote
 
 try:
-    from importlib.metadata import distribution, entry_points
+    from importlib.metadata import entry_points, version
 except ImportError:
-    from importlib_metadata import distribution, entry_points
+    from importlib_metadata import entry_points, version
 
 from catkin_tools.common import is_tty
 from catkin_tools.config import get_verb_aliases
@@ -196,7 +196,7 @@ def catkin_main(sysargs):
     # Check for version
     if '--version' in sysargs:
         print('catkin_tools {} (C) 2014-{} Open Source Robotics Foundation'.format(
-            distribution('catkin_tools').version,
+            version('catkin_tools'),
             date.today().year)
         )
         print('catkin_tools is released under the Apache License,'

--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -18,7 +18,10 @@ import sys
 from datetime import date
 from shlex import quote as cmd_quote
 
-import pkg_resources
+try:
+    from importlib.metadata import distribution, entry_points
+except ImportError:
+    from importlib_metadata import distribution, entry_points
 
 from catkin_tools.common import is_tty
 from catkin_tools.config import get_verb_aliases
@@ -29,16 +32,25 @@ from catkin_tools.terminal_color import test_colors
 
 CATKIN_COMMAND_VERB_GROUP = 'catkin_tools.commands.catkin.verbs'
 
+ENTRY_POINTS = None
+
+
+def _get_entry_points():
+    global ENTRY_POINTS
+    if ENTRY_POINTS is None:
+        ENTRY_POINTS = entry_points()
+    return ENTRY_POINTS
+
 
 def list_verbs():
     verbs = []
-    for entry_point in pkg_resources.iter_entry_points(group=CATKIN_COMMAND_VERB_GROUP):
+    for entry_point in _get_entry_points().get(CATKIN_COMMAND_VERB_GROUP, []):
         verbs.append(entry_point.name)
     return verbs
 
 
 def load_verb_description(verb_name):
-    for entry_point in pkg_resources.iter_entry_points(group=CATKIN_COMMAND_VERB_GROUP):
+    for entry_point in _get_entry_points().get(CATKIN_COMMAND_VERB_GROUP, []):
         if entry_point.name == verb_name:
             return entry_point.load()
 
@@ -184,7 +196,7 @@ def catkin_main(sysargs):
     # Check for version
     if '--version' in sysargs:
         print('catkin_tools {} (C) 2014-{} Open Source Robotics Foundation'.format(
-            pkg_resources.get_distribution('catkin_tools').version,
+            distribution('catkin_tools').version,
             date.today().year)
         )
         print('catkin_tools is released under the Apache License,'

--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -44,13 +44,13 @@ def _get_entry_points():
 
 def list_verbs():
     verbs = []
-    for entry_point in _get_entry_points().get(CATKIN_COMMAND_VERB_GROUP, []):
+    for entry_point in _get_entry_points().select(CATKIN_COMMAND_VERB_GROUP):
         verbs.append(entry_point.name)
     return verbs
 
 
 def load_verb_description(verb_name):
-    for entry_point in _get_entry_points().get(CATKIN_COMMAND_VERB_GROUP, []):
+    for entry_point in _get_entry_points().select(CATKIN_COMMAND_VERB_GROUP):
         if entry_point.name == verb_name:
             return entry_point.load()
 

--- a/catkin_tools/commands/catkin.py
+++ b/catkin_tools/commands/catkin.py
@@ -18,10 +18,7 @@ import sys
 from datetime import date
 from shlex import quote as cmd_quote
 
-try:
-    from importlib.metadata import entry_points, version
-except ImportError:
-    from importlib_metadata import entry_points, version
+from importlib.metadata import entry_points, version
 
 from catkin_tools.common import is_tty
 from catkin_tools.config import get_verb_aliases

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -125,7 +125,7 @@ class Context(object):
         except ImportError:
             from importlib_metadata import entry_points
 
-        for entry_point in entry_points().get(cls.CATKIN_SPACES_GROUP, []):
+        for entry_point in entry_points().select(cls.CATKIN_SPACES_GROUP):
             ep_dict = entry_point.load()
             cls.STORED_KEYS.append(entry_point.name + '_space')
             cls.SPACES[entry_point.name] = ep_dict

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -120,10 +120,7 @@ class Context(object):
         if cls.KEYS:
             return
 
-        try:
-            from importlib.metadata import entry_points
-        except ImportError:
-            from importlib_metadata import entry_points
+        from importlib.metadata import entry_points
 
         for entry_point in entry_points().select(cls.CATKIN_SPACES_GROUP):
             ep_dict = entry_point.load()

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -120,9 +120,12 @@ class Context(object):
         if cls.KEYS:
             return
 
-        from pkg_resources import iter_entry_points
+        try:
+            from importlib.metadata import entry_points
+        except ImportError:
+            from importlib_metadata import entry_points
 
-        for entry_point in iter_entry_points(group=cls.CATKIN_SPACES_GROUP):
+        for entry_point in entry_points().get(cls.CATKIN_SPACES_GROUP, []):
             ep_dict = entry_point.load()
             cls.STORED_KEYS.append(entry_point.name + '_space')
             cls.SPACES[entry_point.name] = ep_dict

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -15,7 +15,11 @@
 import os
 import shutil
 
-import pkg_resources
+try:
+    from importlib.metadata import distribution
+except ImportError:
+    from importlib_metadata import distribution
+
 import yaml
 
 from .common import mkdir_p
@@ -138,7 +142,7 @@ def migrate_metadata(workspace_path):
 
     # Check metadata version
     last_version = None
-    current_version = pkg_resources.require("catkin_tools")[0].version
+    current_version = distribution("catkin_tools").version
     version_file_path = os.path.join(metadata_root_path, 'VERSION')
 
     # Read the VERSION file

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -15,10 +15,7 @@
 import os
 import shutil
 
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
+from importlib.metadata import version
 
 import yaml
 

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -16,9 +16,9 @@ import os
 import shutil
 
 try:
-    from importlib.metadata import distribution
+    from importlib.metadata import version
 except ImportError:
-    from importlib_metadata import distribution
+    from importlib_metadata import version
 
 import yaml
 
@@ -142,7 +142,7 @@ def migrate_metadata(workspace_path):
 
     # Check metadata version
     last_version = None
-    current_version = distribution("catkin_tools").version
+    current_version = version("catkin_tools")
     version_file_path = os.path.join(metadata_root_path, 'VERSION')
 
     # Read the VERSION file

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -21,10 +21,7 @@ import time
 import traceback
 from queue import Queue
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 import yaml
 

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -484,7 +484,7 @@ def build_isolated_workspace(
     # Get all build type plugins
     build_job_creators = {
         ep.name: ep.load()['create_build_job']
-        for ep in entry_points().get('catkin_tools.jobs', [])
+        for ep in entry_points().select('catkin_tools.jobs')
     }
 
     # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -21,7 +21,11 @@ import time
 import traceback
 from queue import Queue
 
-import pkg_resources
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 import yaml
 
 try:
@@ -480,7 +484,7 @@ def build_isolated_workspace(
     # Get all build type plugins
     build_job_creators = {
         ep.name: ep.load()['create_build_job']
-        for ep in pkg_resources.iter_entry_points(group='catkin_tools.jobs')
+        for ep in entry_points().get('catkin_tools.jobs', [])
     }
 
     # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -129,7 +129,7 @@ def clean_packages(
         # Get all build type plugins
         clean_job_creators = {
             ep.name: ep.load()['create_clean_job']
-            for ep in entry_points().get('catkin_tools.jobs', [])
+            for ep in entry_points().select('catkin_tools.jobs')
         }
 
         # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -19,7 +19,10 @@ import time
 import traceback
 from queue import Queue
 
-import pkg_resources
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 
 from catkin_tools.terminal_color import fmt
 
@@ -126,7 +129,7 @@ def clean_packages(
         # Get all build type plugins
         clean_job_creators = {
             ep.name: ep.load()['create_clean_job']
-            for ep in pkg_resources.iter_entry_points(group='catkin_tools.jobs')
+            for ep in entry_points().get('catkin_tools.jobs', [])
         }
 
         # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_clean/clean.py
+++ b/catkin_tools/verbs/catkin_clean/clean.py
@@ -19,10 +19,7 @@ import time
 import traceback
 from queue import Queue
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from catkin_tools.terminal_color import fmt
 

--- a/catkin_tools/verbs/catkin_test/test.py
+++ b/catkin_tools/verbs/catkin_test/test.py
@@ -90,7 +90,7 @@ def test_workspace(
     # Get all build type plugins
     test_job_creators = {
         ep.name: ep.load()['create_test_job']
-        for ep in entry_points().get('catkin_tools.jobs', [])
+        for ep in entry_points().select('catkin_tools.jobs')
     }
 
     # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_test/test.py
+++ b/catkin_tools/verbs/catkin_test/test.py
@@ -14,10 +14,7 @@ import time
 import traceback
 from queue import Queue
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from catkin_pkg.package import InvalidPackage
 from catkin_pkg.packages import find_packages

--- a/catkin_tools/verbs/catkin_test/test.py
+++ b/catkin_tools/verbs/catkin_test/test.py
@@ -14,7 +14,11 @@ import time
 import traceback
 from queue import Queue
 
-import pkg_resources
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 from catkin_pkg.package import InvalidPackage
 from catkin_pkg.packages import find_packages
 from catkin_pkg.topological_order import topological_order_packages
@@ -86,7 +90,7 @@ def test_workspace(
     # Get all build type plugins
     test_job_creators = {
         ep.name: ep.load()['create_test_job']
-        for ep in pkg_resources.iter_entry_points(group='catkin_tools.jobs')
+        for ep in entry_points.get('catkin_tools.jobs', [])
     }
 
     # It's a problem if there aren't any build types available

--- a/catkin_tools/verbs/catkin_test/test.py
+++ b/catkin_tools/verbs/catkin_test/test.py
@@ -90,7 +90,7 @@ def test_workspace(
     # Get all build type plugins
     test_job_creators = {
         ep.name: ep.load()['create_test_job']
-        for ep in entry_points.get('catkin_tools.jobs', [])
+        for ep in entry_points().get('catkin_tools.jobs', [])
     }
 
     # It's a problem if there aren't any build types available

--- a/docs/development/adding_build_types.rst
+++ b/docs/development/adding_build_types.rst
@@ -29,7 +29,7 @@ Regardless of what package the ``entry_point`` is defined in, it will be defined
 This entry in the ``setup.py`` places a file in the ``PYTHONPATH`` when either the ``install`` or the ``develop`` verb is given to ``setup.py``.
 This file relates the key (in this case ``mybuild``) to a module and attribute (in this case ``my_package.some.module`` and ``description``).
 
-Then the ``catkin`` command will use the ``pkg_resources`` modules to retrieve these mapping at run time.
+Then the ``catkin`` command will use the ``importlib.metadata`` modules to retrieve these mapping at run time.
 Any entry for the ``catkin_tools.jobs`` group must point to a ``description`` attribute of a module, where the ``description`` attribute is a ``dict``.
 The ``description`` ``dict`` should take this form:
 
@@ -63,4 +63,3 @@ The signature of the factory callable should be similar to the following:
             jid=package.name,
             deps=dependencies,
             stages=stages)
-

--- a/docs/development/extending_the_catkin_command.rst
+++ b/docs/development/extending_the_catkin_command.rst
@@ -22,7 +22,7 @@ Regardless of what package the ``entry_point`` is defined in, it will be defined
 
 This entry in the ``setup.py`` places a file in the ``PYTHONPATH`` when either the ``install`` or the ``develop`` verb is given to ``setup.py``.
 This file relates the key (in this case ``my_verb``) to a module and attribute (in this case ``my_package.some.module`` and ``description``).
-Then the ``catkin`` command will use the ``pkg_resources`` modules to retrieve these mapping at run time.
+Then the ``catkin`` command will use the ``importlib.metadata`` modules to retrieve these mapping at run time.
 Any entry for the ``catkin_tools.commands.catkin.verbs`` group must point to a ``description`` attribute of a module, where the ``description`` attribute is a ``dict``.
 The ``description`` ``dict`` should take this form (the description from the ``build`` verb for example):
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ class PermissiveInstall(install):
 setup(
     name='catkin_tools',
     version='0.9.4',
-    python_requires='>=3.5',
+    python_requires='>=3.8',
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={
         'catkin_tools': [


### PR DESCRIPTION
`pkg_resources` is deprecated and was causing issues in finding dependencies of `catkin_tools_document`.

I replaced it by `importlib.metadata`. I am not 100% sure the changes in `catkin_tools/metadata.py` are correct.

The call on `entry_points()` is expensive, therefore I added a private function in combination with a global variable. I only applied this in the `commands/catkin.py`. Ideally this is shared between files. Please let me know when you have suggestion to it a bit more cleanly and share it between the files.