### PR TITLE
Add CATKIN_IGNORE_ROS2 marker support for mixed ROS1/ROS2 workspaces

### DIFF
--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -522,8 +522,10 @@ def wide_log(msg, **kwargs):
 
 
 def find_packages(*args, **kwargs):
-    """
-    Crawls the filesystem to find package manifest files. Ignores subfolders if CATKIN_IGNORE is present.
+    """Crawls the filesystem to find package manifest files.
+
+    Ignores subfolders if CATKIN_IGNORE or CATKIN_IGNORE_ROS2 is present.
+
     :param basepath: The path to search in, ``str``
     :param exclude_paths: A list of paths which should not be searched, ``list``
     :param exclude_subspaces: The flag is subfolders containing a .catkin file should not be
@@ -531,7 +533,10 @@ def find_packages(*args, **kwargs):
     :param ignore_markers: A set of filenames to be used as ignore markers, ``set``
     :returns: A list of relative paths containing package manifest files ``list``
     """
-    return _find_packages(*args, ignore_markers={'CATKIN_IGNORE'}, **kwargs)
+    return _find_packages(
+        *args,
+        ignore_markers={'CATKIN_IGNORE', 'CATKIN_IGNORE_ROS2'},
+        **kwargs)
 
 
 def find_enclosing_package(search_start_path=None, ws_path=None, warnings=None, symlinks=True):

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -122,9 +122,10 @@ def prepare_arguments(parser):
     add('--dependents', '--deps', action='store_true', default=False,
         help='Clean the packages which depend on the packages to be cleaned.')
     add('--orphans', action='store_true', default=False,
-        help='Remove products from packages are no longer in the source space. '
-        'Note that this also removes packages which are '
-        'skiplisted or which contain `CATKIN_IGNORE` marker files.')
+        help='Remove products from packages are no longer in the source '
+        'space. Note that this also removes packages which are skiplisted '
+        'or which contain `CATKIN_IGNORE` or `CATKIN_IGNORE_ROS2` marker '
+        'files.')
 
     # Advanced group
     advanced_group = parser.add_argument_group(


### PR DESCRIPTION
This PR adds support for a new marker file `CATKIN_IGNORE_ROS2` to enable better coexistence of ROS1 and ROS2 packages in the same workspace.

## Problem
Currently, when using `CATKIN_IGNORE` in a mixed ROS1/ROS2 workspace:
- Both catkin_tools and colcon recognize and ignore packages with `CATKIN_IGNORE`
- This makes it impossible to have catkin_tools ignore ROS2 packages while allowing colcon to build them

## Solution
Introduce a new marker file `CATKIN_IGNORE_ROS2` that:
- Is recognized only by catkin_tools (colcon does not recognize it)
- Allows catkin_tools to skip ROS2 packages without affecting colcon's behavior
- Maintains backward compatibility with existing `CATKIN_IGNORE` functionality

## Changes
- Added `CATKIN_IGNORE_ROS2` to the ignore_markers set in `find_packages()`
- Updated help message in catkin clean command to mention the new marker

## Usage
For ROS2 packages that should be ignored by catkin_tools but built by colcon:
```bash
touch ros2_package/CATKIN_IGNORE_ROS2
```

This enables truly mixed ROS1/ROS2 workspaces where each build tool can operate independently.